### PR TITLE
Fix: SafeRender the entire workspace

### DIFF
--- a/rails/client/app/bundles/Kaiju/components/Component/components/SafeRender/SafeRender.jsx
+++ b/rails/client/app/bundles/Kaiju/components/Component/components/SafeRender/SafeRender.jsx
@@ -6,10 +6,6 @@ const propTypes = {
    * Child nodes
    */
   children: PropTypes.node,
-  /**
-   * The Component type
-   */
-  type: PropTypes.node,
 };
 
 class SafeRender extends React.Component {
@@ -25,7 +21,7 @@ class SafeRender extends React.Component {
 
   render() {
     if (this.state.error) {
-      return <div>{this.props.type}: Failed to Render</div>;
+      return <div>{this.state.error.toString()}</div>;
     }
     return this.props.children;
   }

--- a/rails/client/app/bundles/Kaiju/components/Component/containers/ElementContainer.jsx
+++ b/rails/client/app/bundles/Kaiju/components/Component/containers/ElementContainer.jsx
@@ -99,7 +99,7 @@ class Element extends React.Component {
       }
     });
 
-    return <SafeRender type={type}>{React.createElement(componentMap[type], props)}</SafeRender>;
+    return <SafeRender>{React.createElement(componentMap[type], props)}</SafeRender>;
   }
 }
 

--- a/rails/client/app/bundles/Kaiju/components/Preview/Preview.jsx
+++ b/rails/client/app/bundles/Kaiju/components/Preview/Preview.jsx
@@ -34,7 +34,7 @@ const Preview = ({ ast }) => {
   return (
     <Base className="kaiju-Preview" locale="en-US">
       <SafeRender>
-        {React.createElement('div', { ...generateProperties(ast.properties), className: `kaiju-${ast.name}` })}
+        {React.createElement('div', { ...generateProperties(ast.properties) })}
       </SafeRender>
     </Base>
   );

--- a/rails/client/app/bundles/Kaiju/components/Preview/Preview.jsx
+++ b/rails/client/app/bundles/Kaiju/components/Preview/Preview.jsx
@@ -20,7 +20,7 @@ const Preview = ({ ast }) => {
       } else if (type === 'Array' || type === 'Hash') {
         parameters[objectKey] = generateProperties(value);
       } else if (type === 'Component') {
-        parameters[objectKey] = <SafeRender key={id} type={value.type}>{React.createElement(componentMap[value.type], { ...generateProperties(value.properties) })}</SafeRender>;
+        parameters[objectKey] = React.createElement(componentMap[value.type], { ...generateProperties(value.properties), key: id });
       } else if (type === 'Number') {
         parameters[objectKey] = Number(value);
       } else {
@@ -33,7 +33,9 @@ const Preview = ({ ast }) => {
 
   return (
     <Base className="kaiju-Preview" locale="en-US">
-      {React.createElement('div', { ...generateProperties(ast.properties), className: `kaiju-${ast.name}` })}
+      <SafeRender>
+        {React.createElement('div', { ...generateProperties(ast.properties), className: `kaiju-${ast.name}` })}
+      </SafeRender>
     </Base>
   );
 };


### PR DESCRIPTION
Previously each individual React element within the preview would be wrapped in a SafeRender component to conditionally render an error if one occurred. 

This caused errors for components that needed to read props directly off of children because they would read the SafeRender props instead of the actual child's props. 

For the preview the entire workspace is wrapped in a single SafeRender that will display the error that occurred.