### PR TITLE
Fix - Disable the ability to drag the entire workspace

### DIFF
--- a/rails/client/app/bundles/Kaiju/components/Component/utilities/drag.js
+++ b/rails/client/app/bundles/Kaiju/components/Component/utilities/drag.js
@@ -3,7 +3,7 @@ import drag from '../../../utilities/drag/drag';
 
 const initializeDrag = () => {
   drag({
-    canMove: target => target.hasAttribute('data-kaiju-component-type'),
+    canMove: target => target.hasAttribute('data-kaiju-component-type') && target.getAttribute('data-kaiju-component-type') !== 'kaiju::Workspace',
     isSortable: target => target.hasAttribute('data-kaiju-sortable'),
     stopPropagation: (target) => {
       const stop = target.classList.contains('kaiju-Placeholder');

--- a/rails/client/app/bundles/Kaiju/components/Project/components/Layers/Layers.jsx
+++ b/rails/client/app/bundles/Kaiju/components/Project/components/Layers/Layers.jsx
@@ -65,6 +65,10 @@ class Layers extends React.Component {
       }
     });
 
+    if (id === this.props.root) {
+      data.id = 'root';
+    }
+
     const layer = <Layer id={id} isDuplicable={!!insertAfterUrl} isSelected={isSelected} type={display || name} />;
     if (children.length > 0) {
       return <TreeView header={layer} {...data}>{children}</TreeView>;

--- a/rails/client/app/bundles/Kaiju/components/Project/utilities/drag.js
+++ b/rails/client/app/bundles/Kaiju/components/Project/utilities/drag.js
@@ -3,7 +3,7 @@ import { destroy, postMessage, select } from '../utilities/messenger';
 
 const initializeDrag = () => {
   drag({
-    canMove: target => target.hasAttribute('data-kaiju-component-id'),
+    canMove: target => target.hasAttribute('data-kaiju-component-id') && target.id !== 'root',
     isSortable: target => target.hasAttribute('data-kaiju-sortable'),
     onDragStart: (event, target) => {
       select(null);


### PR DESCRIPTION
### Summary
Disable the ability to drag the entire workspace. This prevents nesting workspaces.

Thanks for contributing to Kaiju.
@cerner/kaiju

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
