### PR TITLE
Travis CI will build and push latest docker images to dockerhub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,11 @@ branches:
 cache:
   directories:
     - node_modules
+after_success:
+  - if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
+    docker build -t cerner/kaiju-rails:latest ./rails;
+    docker build -t cerner/kaiju-node:latest ./node;
+    docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD";
+    docker push cerner/kaiju-rails:latest;
+    docker push cerner/kaiju-node:latest;
+    fi

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Kaiju is great for rapid prototyping and facilitating collaboration between engi
 
 To run the app, spin up a couple of docker containers with compose and navigate to localhost.
 ```
+docker-compose pull
 docker-compose up
 ```
 
@@ -31,11 +32,13 @@ docker-compose up
 To develop the app, install dependancies and spin rails and node server and navigate to localhost:3000. Running npm install in the root kaiju directory will install npm and rails dependancies.
 ```
 npm install
+npm install foreman -g
 
-foreman start -f Procfile
+nf start
 ```
 
 ## Usage
+If you haven't setup an IDP you'll be greeted with the mock identiy provider. This looks shady, but it's just a pass through provided by omniauth. Any username/email is accepted. That said, please don't use this IDP in production.
 
 After log-in the first step is to create a project. Each new project has a default workspace. The workspace is where you will be creating your new components. Drag a component from the left column to the workspace to drop the component. With this drag and drop system you can build out a tree of nested UI components with a layout as the root. The layers of the workspace will be displayed in the bottom left corner of the editor. The properties of the dropped components can be modified by editing the fields displayed in the right column.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   proxy:
-    image: traefik
+    image: traefik:1.4.4
     command: --web --docker --docker.domain=docker.localhost --logLevel=DEBUG
     networks:
       - webgateway
@@ -15,6 +15,7 @@ services:
       - /dev/null:/traefik.toml
 
   node:
+    image: cerner/kaiju-node:latest
     build: ./node/
     depends_on:
       - proxy
@@ -32,6 +33,7 @@ services:
       - "traefik.port=8080"
 
   rails:
+    image: cerner/kaiju-rails:latest
     build: ./rails/
     environment:
       - SECRET_KEY_BASE=980453e07f6f1a473091a79dc0c5109d6e350509a5b47d96b9bc55ce40e3b45ce2959919e9e528602c3a7a7c169c5e01596feeb8328ef51063514641b964d917
@@ -50,7 +52,7 @@ services:
       - "traefik.port=3000"
 
   redis:
-    image: redis
+    image: redis:3.2
     networks:
       - webgateway
     ports:

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -12,6 +12,6 @@ ADD . $App_Home
 
 # Install Node Dependencies
 RUN npm run clean
-RUN npm install --unsafe-perm
+RUN npm install --unsafe-perm --silent
 
 CMD npm start

--- a/rails/Dockerfile
+++ b/rails/Dockerfile
@@ -26,9 +26,6 @@ ADD . $App_Home
 # Copy cached npm modules into client directory
 RUN npm run clean && cp -a /tmp/node_modules $APP_HOME/client
 
-# Cheat, without this folder existing, precompile will fail
-RUN mkdir $APP_HOME/app/assets/webpack; exit 0
-
 # Precompile Assets
 RUN bundle exec rake assets:precompile
 


### PR DESCRIPTION
### Summary
Changes
- Travis CI will automatically build docker images and push them to docker hub on non pull request master branch builds.
- Docker compose file now specifies traefik and redis images as well as specifying images for kaiju-node and kaiju-rails.
- ReadME has been updated to recommend a docker-compose pull before docker-compose build to pull the latest node and rails docker images instead of building them from scratch.
- node docker file now installs silently.
- rails docker file now removes an unneeded hack.

Thanks for contributing to Kaiju.
@cerner/kaiju

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
