### PR TITLE
Enable node server for cases when the root url is unknown

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,6 @@ COPY . /app
 
 # Node Env
 ENV NODE_ENV=production
-ENV KAIJU_RAILS_SERVER_URL http://localhost
-ENV KAIJU_AUTH_REDIRECT_URL http://localhost/auth
 
 # Rails Env
 ENV RAILS_ENV production

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,11 +8,8 @@ services:
       - webgateway
     ports:
       - "80:80"
-      - "3000:3000"
-      - "8080:8080"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - /dev/null:/traefik.toml
 
   node:
     image: cerner/kaiju-node:latest
@@ -25,8 +22,7 @@ services:
     environment:
       - NODE_ENV=production
       - REDIS_URL=redis://redis:6379/0
-      - KAIJU_RAILS_SERVER_URL=http://rails:3000
-      - KAIJU_AUTH_REDIRECT_URL=http://localhost/auth
+      - KAIJU_RAILS_SERVER_URL=http://proxy
     labels:
       - "traefik.backend=node"
       - "traefik.frontend.rule=Path: /projects/{id}/workspaces/{id}/code, /projects/{id}/workspaces/{id}/preview, /projects/{id}/workspaces/{id}/preview_files/{id}, /projects/{id}/workspaces/{id}/code_files/src/{id}"
@@ -55,8 +51,6 @@ services:
     image: redis:3.2
     networks:
       - webgateway
-    ports:
-      - "6379:6379"
     command: redis-server
 
 networks:

--- a/node/appConfig.js
+++ b/node/appConfig.js
@@ -7,11 +7,13 @@ import projectTypes from './service/controllers/projectTypes';
 import railsSession from './service/middlewares/RailsRedisSession';
 import auth from './service/middlewares/Authentication';
 import csrfToken from './service/middlewares/CsrfToken';
+import fullUrl from './service/middlewares/FullUrl';
 
 export default function configure(app) {
   app.use(cookieParser());
+  app.use(fullUrl());
   app.use(railsSession(config.get('cookieKey')));
-  app.use(auth(config.get('authRedirectUrl')));
+  app.use(auth());
   app.use(csrfToken());
 
   app.set('view engine', 'pug');

--- a/node/config/default.js
+++ b/node/config/default.js
@@ -1,8 +1,6 @@
 module.exports = {
   cookieKey: '_dev_session_id',
-  railsServerUrl: 'http://localhost:3000/',
   redisPrefix: 'kaiju:dev:',
   redisUrl: 'redis://localhost:6379/0',
   disableFsCache: true,
-  authRedirectUrl: 'http://localhost:3000/auth',
 };

--- a/node/config/development.js
+++ b/node/config/development.js
@@ -1,4 +1,4 @@
 module.exports = {
-  railsServerUrl: 'http://localhost:3000/',
-  authRedirectUrl: 'http://localhost:3000/',
+  railsServerUrl: 'http://localhost:3000',
+  authRedirectUrl: 'http://localhost:3000',
 };

--- a/node/config/development.js
+++ b/node/config/development.js
@@ -1,6 +1,4 @@
 module.exports = {
-  cookieKey: '_test_session_id',
-  redisPrefix: 'kaiju:test:',
   railsServerUrl: 'http://localhost:3000/',
   authRedirectUrl: 'http://localhost:3000/',
 };

--- a/node/config/production.js
+++ b/node/config/production.js
@@ -4,5 +4,4 @@ module.exports = {
   redisPrefix: 'kaiju:prod:',
   redisUrl: process.env.REDIS_URL,
   disableFsCache: false,
-  authRedirectUrl: process.env.KAIJU_AUTH_REDIRECT_URL,
 };

--- a/node/config/test.js
+++ b/node/config/test.js
@@ -1,6 +1,6 @@
 module.exports = {
   cookieKey: '_test_session_id',
   redisPrefix: 'kaiju:test:',
-  railsServerUrl: 'http://localhost:3000/',
-  authRedirectUrl: 'http://localhost:3000/',
+  railsServerUrl: 'http://localhost:3000',
+  authRedirectUrl: 'http://localhost:3000',
 };

--- a/node/service/controllers/code.js
+++ b/node/service/controllers/code.js
@@ -6,7 +6,7 @@ const router = express.Router();
 
 /* GET code listing. */
 router.get('/projects/:projectId/workspaces/:workspaceId/code', (req, res, next) => {
-  const requester = new ServiceRequester(req.cookies);
+  const requester = new ServiceRequester(req.cookies, req);
   const generator = new CodeGenerator(req.params.projectId, req.params.workspaceId, requester);
   generator.generate().then(([, manifest]) => {
     const manifestJson = {
@@ -24,7 +24,7 @@ router.get('/projects/:projectId/workspaces/:workspaceId/code', (req, res, next)
 });
 
 router.get('/projects/:projectId/workspaces/:workspaceId/code_files/*', (req, res, next) => {
-  const requester = new ServiceRequester(req.cookies);
+  const requester = new ServiceRequester(req.cookies, req);
   const filename = req.url.substring(req.url.indexOf('code_files/') + 'code_files/'.length);
   const generator = new CodeGenerator(req.params.projectId, req.params.workspaceId, requester);
   generator.generate().then(([, , fs]) => {

--- a/node/service/controllers/preview.js
+++ b/node/service/controllers/preview.js
@@ -6,7 +6,7 @@ const router = express.Router();
 
 /* GET code listing. */
 router.get('/projects/:projectId/workspaces/:workspaceId/preview', (req, res, next) => {
-  const requester = new ServiceRequester(req.cookies);
+  const requester = new ServiceRequester(req.cookies, req);
   const generator = new PreviewGenerator(req.params.projectId, req.params.workspaceId, requester);
   generator.generate().then(([name, entry]) => {
     res.render('preview', {
@@ -18,7 +18,7 @@ router.get('/projects/:projectId/workspaces/:workspaceId/preview', (req, res, ne
 });
 
 router.get('/projects/:projectId/workspaces/:workspaceId/preview_files/*', (req, res, next) => {
-  const requester = new ServiceRequester(req.cookies);
+  const requester = new ServiceRequester(req.cookies, req);
   const filename = req.url.substring(req.url.indexOf('preview_files/') + 'preview_files/'.length);
   const generator = new PreviewGenerator(req.params.projectId, req.params.workspaceId, requester);
   generator.generate().then(([, , fs]) => {

--- a/node/service/middlewares/Authentication.js
+++ b/node/service/middlewares/Authentication.js
@@ -1,18 +1,14 @@
-import url from 'url';
+import config from 'config';
 
-function fullUrl(req) {
-  return url.format({
-    protocol: req.protocol,
-    host: req.get('host'),
-    pathname: req.originalUrl,
-  });
-}
-
-export default function fn(redirectUrl) {
+export default function fn() {
   return function authMiddleware(req, res, next) {
     req.railsSession.session().then((session) => {
       if (!session || !session.user_id) {
-        res.redirect(`${redirectUrl}?origin=${fullUrl(req)}`);
+        let redirectUrl = req.fullUrl();
+        if (config.has('authRedirectUrl')) {
+          redirectUrl = config.get('authRedirectUrl');
+        }
+        res.redirect(`${redirectUrl}/auth?origin=${req.fullUrl()}`);
       } else {
         next();
       }

--- a/node/service/middlewares/FullUrl.js
+++ b/node/service/middlewares/FullUrl.js
@@ -8,7 +8,7 @@ export default function fn() {
         host: req.get('host'),
         pathname: req.originalUrl,
       });
-    }
+    };
     next();
-  }
+  };
 }

--- a/node/service/middlewares/FullUrl.js
+++ b/node/service/middlewares/FullUrl.js
@@ -1,0 +1,14 @@
+import url from 'url';
+
+export default function fn() {
+  return function fullUrlMiddleware(req, res, next) {
+    req.fullUrl = function fullUrl() {
+      return url.format({
+        protocol: req.protocol,
+        host: req.get('host'),
+        pathname: req.originalUrl,
+      });
+    }
+    next();
+  }
+}

--- a/node/service/utils/ServiceRequester.js
+++ b/node/service/utils/ServiceRequester.js
@@ -5,15 +5,19 @@ const { URL } = require('url');
 
 
 class ServiceRequestor {
-  constructor(cookies) {
+  constructor(cookies, req) {
     this.sessionName = config.get('cookieKey');
     this.sessionId = cookies[this.sessionName];
     this.requestPromise = rp;
+    this.baseURL = req.fullUrl();
+    if (config.has('railsServerUrl')) {
+      this.baseURL = config.get('railsServerUrl');
+    }
   }
 
   request(path) {
     const options = {
-      url: new URL(path, config.get('railsServerUrl')),
+      url: new URL(path, this.baseURL),
       headers: {
         Cookie: `${this.sessionName}=${this.sessionId}`,
       },

--- a/node/service_tests/jest/middlewares/Authentication.test.js
+++ b/node/service_tests/jest/middlewares/Authentication.test.js
@@ -1,58 +1,72 @@
+import config from 'config';
 import auth from '../../../service/middlewares/Authentication';
 
 describe('authMiddleware', () => {
   it('should call the next function', (done) => {
-    const redirectUrl = 'derp';
     const mockReq = {
-      protocol: 'http',
-      host: 'derp.com',
-      originalUrl: '/herp/',
+      fullUrl: () => 'http://derp.com/herp/',
       railsSession: {
         session: () => Promise.resolve({ user_id: '12345' }),
       },
     };
     const mockRes = undefined;
-    auth(redirectUrl)(mockReq, mockRes, () => {
+    auth()(mockReq, mockRes, () => {
       done();
     });
   });
 
   it('should redirect if no user id is found in the session', (done) => {
-    const redirectUrl = 'derp';
+    const oldHasFunc = config.has;
+    config.has = () => false;
     const mockReq = {
-      protocol: 'http',
-      originalUrl: '/herp/',
-      get: () => 'derp.com',
+      fullUrl: () => 'http://derp.com/herp',
       railsSession: {
         session: () => Promise.resolve({ some: 'junk' }),
       },
     };
     const mockRes = {
       redirect: (url) => {
-        expect(url).toBe('derp?origin=http://derp.com/herp/');
+        expect(url).toBe('http://derp.com/herp/auth?origin=http://derp.com/herp');
+        config.has = oldHasFunc;
         done();
       },
     };
-    auth(redirectUrl)(mockReq, mockRes);
+    auth()(mockReq, mockRes);
   });
 
   it('should redirect if there is no session', (done) => {
-    const redirectUrl = 'derp';
+    const oldHasFunc = config.has;
+    config.has = () => false;
     const mockReq = {
-      protocol: 'http',
-      originalUrl: '/herp/',
-      get: () => 'derp.com',
+      fullUrl: () => 'http://derp.com/herp',
       railsSession: {
         session: () => Promise.resolve(undefined),
       },
     };
     const mockRes = {
       redirect: (url) => {
-        expect(url).toBe('derp?origin=http://derp.com/herp/');
+        expect(url).toBe('http://derp.com/herp/auth?origin=http://derp.com/herp');
+        config.has = oldHasFunc;
         done();
       },
     };
-    auth(redirectUrl)(mockReq, mockRes);
+    auth()(mockReq, mockRes);
+  });
+
+  it('should use the config if present', (done) => {
+    const mockReq = {
+      fullUrl: () => 'http://derp.com/herp',
+      railsSession: {
+        session: () => Promise.resolve(undefined),
+      },
+    };
+    const mockRes = {
+      redirect: (url) => {
+        expect(url).toBe('http://localhost:3000/auth?origin=http://derp.com/herp');
+        done();
+      },
+    };
+    auth()(mockReq, mockRes);
   });
 });
 

--- a/node/service_tests/jest/middlewares/FullUrl.test.js
+++ b/node/service_tests/jest/middlewares/FullUrl.test.js
@@ -1,0 +1,16 @@
+import fullUrl from '../../../service/middlewares/FullUrl';
+
+describe('fullUrlMiddleware', () => {
+  it('should add a method to get the full url', (done) => {
+    const mockReq = {
+      protocol: 'http',
+      get: () => 'derp.com',
+      originalUrl: '/herp',
+    };
+    const mockRes = undefined;
+    fullUrl()(mockReq, mockRes, () => {
+      expect(mockReq.fullUrl()).toBe('http://derp.com/herp');
+      done();
+    });
+  });
+});

--- a/node/service_tests/jest/utils/ServiceRequester.test.js
+++ b/node/service_tests/jest/utils/ServiceRequester.test.js
@@ -2,29 +2,56 @@ import config from 'config';
 import Requester from '../../../service/utils/ServiceRequester';
 
 describe('ServiceRequester', () => {
-  it('constructs a requester', () => {
-    const cookies = { [config.get('cookieKey')]: 'cookie' };
-    const req = new Requester(cookies);
-    expect(req.sessionName).toBe(config.get('cookieKey'));
-    expect(req.sessionId).toBe('cookie');
-    expect(req.requestPromise).toBeDefined();
+  describe('constructor', () => {
+    it('constructs a requester', () => {
+      const cookies = { [config.get('cookieKey')]: 'cookie' };
+      const req = {
+        fullUrl: () => 'derp',
+      };
+      const requester = new Requester(cookies, req);
+      expect(requester.sessionName).toBe(config.get('cookieKey'));
+      expect(requester.sessionId).toBe('cookie');
+      expect(requester.requestPromise).toBeDefined();
+      expect(requester.baseURL).toBe('http://localhost:3000');
+    });
+
+    it('constructs a requester with undefined config', () => {
+      const cookies = { [config.get('cookieKey')]: 'cookie' };
+      const oldHasFunc = config.has;
+      config.has = () => false;
+      const req = {
+        fullUrl: () => 'derp',
+      };
+      const requester = new Requester(cookies, req);
+      config.has = oldHasFunc;
+
+      expect(requester.sessionName).toBe(config.get('cookieKey'));
+      expect(requester.sessionId).toBe('cookie');
+      expect(requester.requestPromise).toBeDefined();
+      expect(requester.baseURL).toBe('derp');
+    });
   });
 
-  it('calls request with created options', (done) => {
-    const cookies = { [config.get('cookieKey')]: 'cookie' };
-    const req = new Requester(cookies);
+  describe('request', () => {
+    it('calls request with created options', (done) => {
+      const cookies = { [config.get('cookieKey')]: 'cookie' };
+      const req = {
+        fullUrl: () => 'derp',
+      };
+      const requester = new Requester(cookies, req);
 
-    req.requestPromise = (options) => {
-      expect(options.url.href).toBe('http://localhost:3000/derp');
-      expect(options.headers.Cookie).toBe(`${config.get('cookieKey')}=cookie`);
-      expect(options.json).toBe(true);
+      requester.requestPromise = (options) => {
+        expect(options.url.href).toBe('http://localhost:3000/derp');
+        expect(options.headers.Cookie).toBe(`${config.get('cookieKey')}=cookie`);
+        expect(options.json).toBe(true);
 
-      return Promise.resolve('herp');
-    };
+        return Promise.resolve('herp');
+      };
 
-    req.request('/derp').then((response) => {
-      expect(response).toBe('herp');
-      done();
+      requester.request('/derp').then((response) => {
+        expect(response).toBe('herp');
+        done();
+      });
     });
   });
 });

--- a/traefik.toml
+++ b/traefik.toml
@@ -23,4 +23,4 @@ defaultEntryPoints = ["http"]
   backend = "node"
   passHostHeader = true
     [frontends.node.routes.test_1]
-    # rule = "Path: /projects/{id}/workspaces/{id}/code, /projects/{id}/workspaces/{id}/preview, /projects/{id}/workspaces/{id}/preview_files/{id}, /projects/{id}/workspaces/{id}/code_files/src/{id}"
+    rule = "Path: /projects/{id}/workspaces/{id}/code, /projects/{id}/workspaces/{id}/preview, /projects/{id}/workspaces/{id}/preview_files/{id}, /projects/{id}/workspaces/{id}/code_files/src/{id}"


### PR DESCRIPTION
### Summary
When the root url is unknown use the request url, the proxy handles the request in all cases except when the root url is localhost in docker compose, in that case an override is required to appropriately re-direct the call.

I also added an express middleware to get the full url from the request.

Thanks for contributing to Kaiju.
@cerner/kaiju

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
