### PR TITLE
Clean up traefik rules.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - KAIJU_RAILS_SERVER_URL=http://proxy
     labels:
       - "traefik.backend=node"
-      - "traefik.frontend.rule=Path: /projects/{id}/workspaces/{id}/code, /projects/{id}/workspaces/{id}/preview, /projects/{id}/workspaces/{id}/preview_files/{id}, /projects/{id}/workspaces/{id}/code_files/src/{id}"
+      - "traefik.frontend.rule=PathPrefix: /projects/{id}/workspaces/{id}/preview, /projects/{id}/workspaces/{id}/preview_files, /projects/{id}/workspaces/{id}/code_files"
       - "traefik.port=8080"
 
   rails:

--- a/traefik.toml
+++ b/traefik.toml
@@ -23,4 +23,4 @@ defaultEntryPoints = ["http"]
   backend = "node"
   passHostHeader = true
     [frontends.node.routes.test_1]
-    rule = "Path: /projects/{id}/workspaces/{id}/code, /projects/{id}/workspaces/{id}/preview, /projects/{id}/workspaces/{id}/preview_files/{id}, /projects/{id}/workspaces/{id}/code_files/src/{id}"
+    rule = "PathPrefix: /projects/{id}/workspaces/{id}/preview, /projects/{id}/workspaces/{id}/preview_files, /projects/{id}/workspaces/{id}/code_files"


### PR DESCRIPTION
### Summary
Remove rule to redirect to the rails server for the code route, until code build by the node server is presentable.

Thanks for contributing to Kaiju.
@cerner/kaiju

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
