### PR TITLE
Update - Added copy and paste keyboard shortcuts

### DIFF
--- a/rails/client/app/bundles/Kaiju/components/Component/utilities/dispatcher.js
+++ b/rails/client/app/bundles/Kaiju/components/Component/utilities/dispatcher.js
@@ -288,6 +288,12 @@ const registerDispatcher = (store, root) => {
         return;
       }
 
+      // Prevents replacing an entire workspace if the workspace has more than 1 child
+      // A workspace with a single child will have two properties
+      if (clipboard.type === 'kaiju::Workspace' && Object.keys(fetch(root).properties).length > 2) {
+        return;
+      }
+
       replace(target, clipboard);
     }
   };

--- a/rails/client/app/bundles/Kaiju/components/Component/utilities/dispatcher.js
+++ b/rails/client/app/bundles/Kaiju/components/Component/utilities/dispatcher.js
@@ -281,7 +281,9 @@ const registerDispatcher = (store, root) => {
     const clipboard = localStorage.clipboard ? JSON.parse(localStorage.clipboard) : null;
 
     if (clipboard && selectedComponent && selectedComponent.type === 'kaiju::Placeholder') {
-      const target = selectedComponent.parent === root ? selectedComponent.parent : selectedComponent.id;
+      const target = selectedComponent.parent === root && clipboard.type === 'kaiju::Workspace' ?
+                     selectedComponent.parent :
+                     selectedComponent.id;
 
       // Kaiju does not allow nesting workspaces
       if (clipboard.type === 'kaiju::Workspace' && target !== root) {

--- a/rails/client/app/bundles/Kaiju/components/Component/utilities/dispatcher.js
+++ b/rails/client/app/bundles/Kaiju/components/Component/utilities/dispatcher.js
@@ -149,7 +149,7 @@ const registerDispatcher = (store, root) => {
    */
   const replace = (id, properties) => {
     const { parent, url } = fetch(id);
-    put(url, { component: properties }, () => refresh(parent, id));
+    put(url, { component: properties }, () => refresh(parent || root, id));
   };
 
   /**
@@ -263,6 +263,36 @@ const registerDispatcher = (store, root) => {
   };
 
   /**
+   * Copies the selected component into the clipboard
+   */
+  const copy = () => {
+    const selectedComponent = fetch(getSelectedComponent());
+
+    if (selectedComponent) {
+      localStorage.clipboard = JSON.stringify(serialize(selectedComponent));
+    }
+  };
+
+  /**
+   * Replaces a placeholder with contents from the clipboard
+   */
+  const paste = () => {
+    const selectedComponent = fetch(getSelectedComponent());
+    const clipboard = localStorage.clipboard ? JSON.parse(localStorage.clipboard) : null;
+
+    if (clipboard && selectedComponent && selectedComponent.type === 'kaiju::Placeholder') {
+      const target = selectedComponent.parent === root ? selectedComponent.parent : selectedComponent.id;
+
+      // Kaiju does not allow nesting workspaces
+      if (clipboard.type === 'kaiju::Workspace' && target !== root) {
+        return;
+      }
+
+      replace(target, clipboard);
+    }
+  };
+
+  /**
    * Dispatches messages to the appropriate functions
    * @param {Object} data - The message data
    */
@@ -291,12 +321,18 @@ const registerDispatcher = (store, root) => {
       replace(data.target, data.properties || lastDestroyed);
     } else if (message === 'kaiju-update') {
       update(id, data.property, data.value);
+    } else if (message === 'kaiju-copy') {
+      copy();
+    } else if (message === 'kaiju-paste') {
+      paste();
     }
   };
 
   postUpdate();
   Mousetrap.bind(['esc'], () => select(null));
   Mousetrap.bind(['backspace', 'delete'], () => destroy(getSelectedComponent()));
+  Mousetrap.bind(['command+c', 'ctrl+c'], copy);
+  Mousetrap.bind(['command+v', 'ctrl+v'], paste);
   Mousetrap.bind(['command+z', 'ctrl+z'], undo);
   Mousetrap.bind(['command+shift+z', 'ctrl+shift+z'], redo);
   window.addEventListener('message', dispatchMessage);

--- a/rails/client/app/bundles/Kaiju/components/Project/components/ActionBar/ActionBar.jsx
+++ b/rails/client/app/bundles/Kaiju/components/Project/components/ActionBar/ActionBar.jsx
@@ -4,7 +4,7 @@ import Mousetrap from 'mousetrap';
 import ajax from 'superagent';
 import IconUndo from 'terra-icon/lib/icon/IconReply';
 import IconRedo from 'terra-icon/lib/icon/IconForward';
-import { destroy, refresh, select } from '../../utilities/messenger';
+import { copy, destroy, paste, refresh, select } from '../../utilities/messenger';
 import ActionItem from './ActionItem/ActionItem';
 import Delete from './Delete/Delete';
 import Rename from './Rename/Rename';
@@ -52,6 +52,8 @@ class ActionBar extends React.Component {
   }
 
   componentDidMount() {
+    Mousetrap.bind(['command+c', 'ctrl+c'], copy);
+    Mousetrap.bind(['command+v', 'ctrl+v'], paste);
     Mousetrap.bind(['command+z', 'ctrl+z'], this.undo);
     Mousetrap.bind(['command+shift+z', 'ctrl+shift+z'], this.redo);
     Mousetrap.bind(['backspace', 'delete'], ActionBar.destroy);
@@ -60,6 +62,8 @@ class ActionBar extends React.Component {
   }
 
   componentWillUnmount() {
+    Mousetrap.unbind(['command+c', 'ctrl+c'], copy);
+    Mousetrap.unbind(['command+v', 'ctrl+v'], paste);
     Mousetrap.unbind(['command+z', 'ctrl+z'], this.undo);
     Mousetrap.unbind(['command+shift+z', 'ctrl+shift+z'], this.redo);
     Mousetrap.unbind(['backspace', 'delete'], ActionBar.destroy);

--- a/rails/client/app/bundles/Kaiju/components/Project/utilities/messenger.js
+++ b/rails/client/app/bundles/Kaiju/components/Project/utilities/messenger.js
@@ -71,11 +71,27 @@ const removeHighlight = () => {
   postMessage({ message: 'kaiju-remove-highlight' });
 };
 
+/**
+ * Copies the selected component into the clipboard
+ */
+const copy = () => {
+  postMessage({ message: 'kaiju-copy' });
+};
+
+/**
+ * Pastes a component into a placeholder
+ */
+const paste = () => {
+  postMessage({ message: 'kaiju-paste' });
+};
+
 export {
+  copy,
   destroy,
   duplicate,
   duplicateProperty,
   highlight,
+  paste,
   postMessage,
   refresh,
   removeHighlight,


### PR DESCRIPTION
### Summary
Added keyboard shortcuts for copy and paste.

This enhancement uses the local browser storage for each browser.

### Caveats 
- Cannot copy paste between different types of browsers. ( Copy in Safari -> Paste in Chrome )
- A component may only be pasted into a Placeholder
- A Workspace cannot be copied and pasted as a nested child in another Workspace, however, an entire Workspace can be replaced by the clipboard by pasting into the root placeholder of the Workspace. ( Click the placeholder in a new workspace and paste into it )

### Future considerations

- Clickable copy and paste action buttons
- Add the clipboard as the first item in the editors Component Selection drop down to enable pasting into components that do not have a drop zone placeholder

### Additional information
There were several scenarios that I tested but there may be more.

- Copying an entire workspace and trying to paste it as a nested child
- Copying an entire workspace and overwriting a blank workspace 
- Copying a nested item and replacing any placeholder
- Copying and pasting between open browser tabs ( Kaiju and real browser )

Thanks for contributing to Kaiju.
@cerner/kaiju

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
