### PR TITLE
Fix - Enabled all logged in users to view component attributes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-## Unreleased
+## December 15th, 2017
 ### Fixed
 - Enabled attributes to be viewed by all users
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-## December 15th, 2017
+## Unreleased
 ### Fixed
 - Enabled attributes to be viewed by all users
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+## December 15th, 2017
+### Fixed
+- Enabled attributes to be viewed by all users
+
 ## December 13th, 2017
 ### Added
 - Added Kaiju Christmas theme

--- a/rails/app/controllers/components_controller.rb
+++ b/rails/app/controllers/components_controller.rb
@@ -3,7 +3,7 @@ class ComponentsController < ApplicationController
   before_action { fetch_workspace(params[:workspace_id]) }
   before_action { fetch_component(params[:id]) }
   before_action(only: %i[show]) { current_user.add_recent_workspace(params[:project_id], params[:workspace_id]) }
-  before_action(except: %i[show]) { authorize(params[:workspace_object].editors) }
+  before_action(except: %i[show attributes]) { authorize(params[:workspace_object].editors) }
   # GET /projects/1/workspaces/1/components/1
   def show # rubocop:disable Metrics/AbcSize
     # Rails.logger.debug params


### PR DESCRIPTION
### Summary
Users were unable to access attributes on workspaces they were not collaborators on.

Thanks for contributing to Kaiju.
@cerner/kaiju

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
