### PR TITLE
Migrate node preview webpack from kaiju to plugin.

### DIFF
--- a/node/appConfig.js
+++ b/node/appConfig.js
@@ -25,7 +25,7 @@ export default function configure(app) {
 
   // catch 404 and forward to error handler
   app.use((req, res, next) => {
-    const err = new Error('Not Found');
+    const err = new Error(`Not Found: ${req.originalUrl}`);
     err.status = 404;
     next(err);
   });

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -6626,7 +6626,7 @@
       "dev": true
     },
     "kaiju-bundle": {
-      "version": "git+https://github.com/StephenEsser/kaiju-bundle.git#c1f50345ee941b88d615706ca705a376c5d88754",
+      "version": "git+https://github.com/StephenEsser/kaiju-bundle.git#380e1d1cd8f0f1880d8adf68f65df61095825700",
       "requires": {
         "terra-alert": "1.13.0",
         "terra-arrange": "1.16.0",

--- a/node/service/code_generation/CodeGenerator.js
+++ b/node/service/code_generation/CodeGenerator.js
@@ -40,13 +40,10 @@ class CodeGenerator {
     // Retrieve plugin for project
     // Pass AST and FS to Plugin
     // Tell plugin to do it's thing
-    const generateCode = new Promise((resolve) => {
-      PluginManager.plugin('terra').generateCode(ast, fs, (manifest) => {
-        this.cache.cacheFs(ast.name, manifest, fs.data);
-        resolve(manifest);
-      });
+    return PluginManager.plugin('terra').generateCode(ast, fs).then(([manifest, outputFs]) => {
+      this.cache.cacheFs(ast.name, manifest, outputFs.data);
+      return Promise.all([ast.name, manifest, outputFs]);
     });
-    return Promise.all([ast.name, generateCode, fs]);
   }
 
   ast() {

--- a/node/service/kaiju_plugins/DefaultTerraPlugin.js
+++ b/node/service/kaiju_plugins/DefaultTerraPlugin.js
@@ -1,5 +1,6 @@
 import config from './default/preview/webpack.config';
 import generateCode from './default/code/generator';
+import PluginUtils from './PluginUtils';
 
 class DefaultTerraPlugin {
   static generateCode(ast, fs, callback) {
@@ -9,9 +10,15 @@ class DefaultTerraPlugin {
     callback(manifest);
   }
 
-  static generatePreview(manifest, webpackconfig, inputFs, rootPath, callback) {
-    const modifiedConfig = Object.assign({}, webpackconfig, config(rootPath, '/src/derp.jsx', inputFs));
-    callback(modifiedConfig, 'preview.js');
+  // returns a virtual fs containing the preview and the entry filename.
+  static generatePreview(fs, publicPath) {
+    console.log('generatePreview');
+    const modifiedConfig = Object.assign(
+      {}, PluginUtils.defaultWebpackConfig(publicPath), config(PluginUtils.rootPath(), '/src/derp.jsx', fs));
+    return Promise.all([
+      'preview.js',
+      PluginUtils.runCompiler(fs, modifiedConfig),
+    ]);
   }
 
   static componentModules() {

--- a/node/service/kaiju_plugins/DefaultTerraPlugin.js
+++ b/node/service/kaiju_plugins/DefaultTerraPlugin.js
@@ -3,21 +3,21 @@ import generateCode from './default/code/generator';
 import PluginUtils from './PluginUtils';
 
 class DefaultTerraPlugin {
-  static generateCode(ast, fs, callback) {
+  static generateCode(ast, fs) {
     fs.mkdirpSync('/src');
     fs.writeFileSync('/src/derp.jsx', generateCode(ast));
     const manifest = ['/src/derp.jsx'];
-    callback(manifest);
+    return Promise.all([manifest, fs]);
   }
 
   // returns a virtual fs containing the preview and the entry filename.
   static generatePreview(fs, publicPath) {
-    console.log('generatePreview');
+    const webpackFs = PluginUtils.webpackFs(fs);
     const modifiedConfig = Object.assign(
-      {}, PluginUtils.defaultWebpackConfig(publicPath), config(PluginUtils.rootPath(), '/src/derp.jsx', fs));
+      {}, PluginUtils.defaultWebpackConfig(publicPath), config(PluginUtils.rootPath(), '/src/derp.jsx', webpackFs));
     return Promise.all([
       'preview.js',
-      PluginUtils.runCompiler(fs, modifiedConfig),
+      PluginUtils.runCompiler(webpackFs, modifiedConfig),
     ]);
   }
 

--- a/node/service/kaiju_plugins/PluginUtils.js
+++ b/node/service/kaiju_plugins/PluginUtils.js
@@ -1,0 +1,66 @@
+import path from 'path';
+import webpack from 'webpack';
+import MemoryFS from 'memory-fs';
+
+class PluginUtils {
+  static rootPath() {
+    const rpath = path.join(__dirname, '../..');
+    console.log('root path', rpath);
+    return path.join(__dirname, '../..');
+  }
+
+  static defaultWebpackConfig(publicPath) {
+    return {
+      entry: {
+      },
+
+      resolve: {
+        extensions: ['.js'],
+        modules: [`${PluginUtils.rootPath}/node_modules`],
+      },
+
+      output: {
+        path: '/build/',
+        publicPath,
+      },
+
+      plugins: [
+        new webpack.DefinePlugin({
+          'process.env': {
+            NODE_ENV: JSON.stringify('production'),
+          },
+        }),
+      ],
+    };
+  }
+
+  static runCompiler(memoryFs, config) {
+    // plugin returns webpack config + entry path
+    // create webpack compiler
+    // setup compiler filesystem with memory fs
+    const compiler = PluginUtils.webpackCompiler(config, memoryFs);
+    // run compiler
+    return new Promise((resolve, reject) => {
+      compiler.run((err, stats) => {
+        if (err || stats.hasErrors()) {
+          console.log(err);
+          console.log(stats);
+          reject('Preview failed to compile');
+        }
+        resolve(compiler.outputFileSystem);
+      });
+    });
+  }
+
+  static webpackCompiler(config, compilerFs) {
+    const compiler = webpack(config);
+    // hydrate new fs with data
+    compiler.inputFileSystem = compilerFs;
+    compiler.resolvers.normal.fileSystem = compiler.inputFileSystem;
+    // seperate input and output file systems.
+    compiler.outputFileSystem = new MemoryFS();
+    return compiler;
+  }
+}
+
+export default PluginUtils;

--- a/node/service/kaiju_plugins/PluginUtils.js
+++ b/node/service/kaiju_plugins/PluginUtils.js
@@ -1,12 +1,16 @@
 import path from 'path';
 import webpack from 'webpack';
 import MemoryFS from 'memory-fs';
+import fileSystem from 'fs';
+import fallbackFs from '../utils/FallbackFileSystem';
 
 class PluginUtils {
   static rootPath() {
-    const rpath = path.join(__dirname, '../..');
-    console.log('root path', rpath);
     return path.join(__dirname, '../..');
+  }
+
+  static webpackFs(fs) {
+    return fallbackFs(fs.data, fileSystem);
   }
 
   static defaultWebpackConfig(publicPath) {
@@ -43,8 +47,8 @@ class PluginUtils {
     return new Promise((resolve, reject) => {
       compiler.run((err, stats) => {
         if (err || stats.hasErrors()) {
-          console.log(err);
-          console.log(stats);
+          // console.log(err);
+          // console.log(stats);
           reject('Preview failed to compile');
         }
         resolve(compiler.outputFileSystem);

--- a/node/service/preview_generation/PreviewGenerator.js
+++ b/node/service/preview_generation/PreviewGenerator.js
@@ -43,20 +43,11 @@ class PreviewGenerator {
       const compilerFs = fallbackFs(fs.data, fileSystem);
       // find plugin
       // call plugin with fs and webpack config
-      // return Promise.all([memoryFs, PluginManager.plugin('terra').generatePreview(manifest, defaultConfig, rootPath)]);
       return PluginManager.plugin('terra').generatePreview(compilerFs, this.publicPath).then(([entry, outputFileSystem]) => {
         // Cache Preview
         this.cache.cacheFs(name, [], outputFileSystem.data, entry);
-
         return Promise.all([name, entry, outputFileSystem]);
       });
-
-      // return new Promise((resolve) => {
-      //   PluginManager.plugin('terra').generatePreview(compilerFs, (entry, outputFileSystem) => {
-      //     this.cache.cacheFs(name, [], outputFileSystem.data, entry);
-      //     resolve([name, entry, outputFileSystem]);
-      //   });
-      // });
     });
   }
 }

--- a/node/service/preview_generation/PreviewGenerator.js
+++ b/node/service/preview_generation/PreviewGenerator.js
@@ -1,13 +1,7 @@
 import MemoryFS from 'memory-fs';
-import fileSystem from 'fs';
-// import webpack from 'webpack';
-// import path from 'path';
 import CodeGenerator from '../code_generation/CodeGenerator';
 import PluginManager from '../plugin_management/PluginManager';
-import fallbackFs from '../utils/FallbackFileSystem';
 import FsCacheFactory from '../models/FsCacheFactory';
-
-// const rootPath = path.join(__dirname, '../..');
 
 class PreviewGenerator {
   constructor(projectId, workspaceId, requester) {
@@ -38,17 +32,13 @@ class PreviewGenerator {
 
   generatedPreview() {
     const generator = new CodeGenerator(this.projectId, this.workspaceId, this.requester);
-    return generator.generate().then(([name,, fs]) => {
-      // Move to plugin utils
-      const compilerFs = fallbackFs(fs.data, fileSystem);
-      // find plugin
-      // call plugin with fs and webpack config
-      return PluginManager.plugin('terra').generatePreview(compilerFs, this.publicPath).then(([entry, outputFileSystem]) => {
+    return generator.generate().then(([name,, fs]) =>
+      // call plugin with fs and public path
+      PluginManager.plugin('terra').generatePreview(fs, this.publicPath).then(([entry, outputFileSystem]) => {
         // Cache Preview
         this.cache.cacheFs(name, [], outputFileSystem.data, entry);
         return Promise.all([name, entry, outputFileSystem]);
-      });
-    });
+      }));
   }
 }
 

--- a/node/service/preview_generation/PreviewGenerator.js
+++ b/node/service/preview_generation/PreviewGenerator.js
@@ -1,19 +1,20 @@
 import MemoryFS from 'memory-fs';
 import fileSystem from 'fs';
-import webpack from 'webpack';
-import path from 'path';
+// import webpack from 'webpack';
+// import path from 'path';
 import CodeGenerator from '../code_generation/CodeGenerator';
 import PluginManager from '../plugin_management/PluginManager';
 import fallbackFs from '../utils/FallbackFileSystem';
 import FsCacheFactory from '../models/FsCacheFactory';
 
-const rootPath = path.join(__dirname, '../..');
+// const rootPath = path.join(__dirname, '../..');
 
 class PreviewGenerator {
   constructor(projectId, workspaceId, requester) {
     this.projectId = projectId;
     this.workspaceId = workspaceId;
     this.requester = requester;
+    this.publicPath = `/projects/${this.projectId}/workspaces/${this.workspaceId}/preview_files/`;
     this.cache = FsCacheFactory.create(projectId, workspaceId, 'preview_cache', requester);
   }
 
@@ -27,7 +28,6 @@ class PreviewGenerator {
   }
 
   cachedFileSystem() {
-    // console.log('cached preview');
     this.cache.renew();
     return Promise.all([
       this.cache.workspaceName(),
@@ -37,84 +37,27 @@ class PreviewGenerator {
   }
 
   generatedPreview() {
-    return this.retrivePluginConfig().then(([name, memoryFs, config, entryLocation]) => this.runCompiler(name, memoryFs, config, entryLocation));
-  }
-
-  retrivePluginConfig() {
     const generator = new CodeGenerator(this.projectId, this.workspaceId, this.requester);
-    return generator.generate().then(([name, manifest, fs]) => {
-      // hydrate new fs with data
-
-      const defaultConfig = this.defaultWebpackConfig();
+    return generator.generate().then(([name,, fs]) => {
+      // Move to plugin utils
       const compilerFs = fallbackFs(fs.data, fileSystem);
       // find plugin
       // call plugin with fs and webpack config
       // return Promise.all([memoryFs, PluginManager.plugin('terra').generatePreview(manifest, defaultConfig, rootPath)]);
-      return new Promise((resolve) => {
-        PluginManager.plugin('terra').generatePreview(manifest, defaultConfig, compilerFs, rootPath, (config, entryLocation) => {
-          resolve([name, compilerFs, config, entryLocation]);
-        });
+      return PluginManager.plugin('terra').generatePreview(compilerFs, this.publicPath).then(([entry, outputFileSystem]) => {
+        // Cache Preview
+        this.cache.cacheFs(name, [], outputFileSystem.data, entry);
+
+        return Promise.all([name, entry, outputFileSystem]);
       });
+
+      // return new Promise((resolve) => {
+      //   PluginManager.plugin('terra').generatePreview(compilerFs, (entry, outputFileSystem) => {
+      //     this.cache.cacheFs(name, [], outputFileSystem.data, entry);
+      //     resolve([name, entry, outputFileSystem]);
+      //   });
+      // });
     });
-  }
-
-  runCompiler(name, memoryFs, config, entry) {
-    // plugin returns webpack config + entry path
-    // create webpack compiler
-    // setup compiler filesystem with memory fs
-    const compiler = PreviewGenerator.webpackCompiler(config, memoryFs);
-    // run compiler
-    const run = new Promise((resolve, reject) => {
-      compiler.run((err, stats) => {
-        if (err || stats.hasErrors()) {
-          // console.log(err);
-          // console.log(stats);
-          reject('Preview failed to compile');
-        }
-        this.cache.cacheFs(name, [], compiler.outputFileSystem.data, entry);
-        resolve(compiler.outputFileSystem);
-      });
-    });
-    return Promise.all([
-      name,
-      entry,
-      run,
-    ]);
-  }
-
-  defaultWebpackConfig() {
-    return {
-      entry: {
-      },
-
-      resolve: {
-        extensions: ['.js'],
-        modules: [`${rootPath}/node_modules`],
-      },
-
-      output: {
-        path: '/build/',
-        publicPath: `/projects/${this.projectId}/workspaces/${this.workspaceId}/preview_files/`,
-      },
-
-      plugins: [
-        new webpack.DefinePlugin({
-          'process.env': {
-            NODE_ENV: JSON.stringify('production'),
-          },
-        }),
-      ],
-    };
-  }
-
-  static webpackCompiler(config, compilerFs) {
-    const compiler = webpack(config);
-    // hydrate new fs with data
-    compiler.inputFileSystem = fallbackFs(compilerFs.data, compiler.inputFileSystem);
-    compiler.resolvers.normal.fileSystem = compiler.inputFileSystem;
-    // seperate input and output file systems.
-    compiler.outputFileSystem = new MemoryFS();
-    return compiler;
   }
 }
 


### PR DESCRIPTION
### Summary
This change will set us up to allow plugins to decide if they want/need webpack to create their preview.

### Additional Details
Converted plugin from callbacks to promises.
Fallback file system is applied in the plugin.
Broke out common kaiju plugin utils.

Thanks for contributing to Kaiju.
@cerner/kaiju

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
