### PR TITLE
Fixed - Component drop down search case sensitivity

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+## January 9th, 2018
+### Fixed
+- The component drop down search is no longer case sensitive
+
 ## January 5th, 2018
 ### Added
 - Ability to recover deleted projects from the launch page

--- a/rails/client/app/bundles/kaiju/components/Project/components/Form/ComponentSelect/ComponentSelect.jsx
+++ b/rails/client/app/bundles/kaiju/components/Project/components/Form/ComponentSelect/ComponentSelect.jsx
@@ -51,6 +51,7 @@ const ComponentSelect = ({ components, id, url }) => {
       dropdownStyle={{ maxHeight: 300, overflow: 'auto' }}
       onChange={onChange}
       treeDefaultExpandAll
+      filterTreeNode={(input, option) => option.props.title.toLowerCase().includes(input.toLowerCase())}
     >
       {components.map(component => generateTreeView(component))}
     </TreeSelect>


### PR DESCRIPTION
### Summary
The Component drop down search within the editor was previously case sensitive. This fix makes the search case insensitive by providing a custom filter function. 

Thanks for contributing to Kaiju.
@cerner/kaiju

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE

  