### PR TITLE
Do not require authorization to view project reference components

### DIFF
--- a/rails/app/controllers/projects_controller.rb
+++ b/rails/app/controllers/projects_controller.rb
@@ -3,7 +3,7 @@ require 'component_information'
 class ProjectsController < ApplicationController
   include ::ProjectsHelper
   before_action(except: %i[index create new]) { fetch_project(params[:id]) }
-  before_action(except: %i[show index create new]) { authorize(params[:project_object].editors) }
+  before_action(except: %i[show index create new reference_components]) { authorize(params[:project_object].editors) }
 
   # GET /projects/1
   def show # rubocop:disable Metrics/AbcSize


### PR DESCRIPTION
### Summary
There is a bug where when you view a workspace owned by someone else you are not authorized to view the reference components for the project. This PR removes that requirement.

Thanks for contributing to Kaiju.
@cerner/kaiju

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
