### PR TITLE
Removed empty arrays and conditionally refresh components

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,8 @@
-## January 16th, 2018
+## January 17th, 2018
 ### Added
 - Ability to duplicate workspaces from the action bar
-- New Checkbox component
+- Checkbox component
+- Tabs component
 
 ### Fixed
 - The component drop down search is no longer case sensitive

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -11206,7 +11206,9 @@
       }
     },
     "terra-kaiju-plugin": {
-      "version": "git+https://github.com/cerner/terra-kaiju-plugin.git#30a9f504c0eda31d276f0f435ef0f95f47bdecb8",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/terra-kaiju-plugin/-/terra-kaiju-plugin-0.4.0.tgz",
+      "integrity": "sha512-zp3sDnXmH7hbcv9LI7ngllLRoSXOK9tDixNMwd1NtSjMrpyjUbZDiJF45CHx8ajZIiD5j2k9R1dPtgJrIClnYA==",
       "requires": {
         "app-root-path": "2.0.1",
         "autoprefixer": "6.7.7",

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -11206,9 +11206,7 @@
       }
     },
     "terra-kaiju-plugin": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/terra-kaiju-plugin/-/terra-kaiju-plugin-0.3.0.tgz",
-      "integrity": "sha512-QSrCRRxUKuehK8GgrGz90PpmBi9J83ztLDexw6fZEWcWLbwz57JmRy+1U3D4tRcfuFTCtNmXl5UknuBGHMNJXw==",
+      "version": "git+https://github.com/cerner/terra-kaiju-plugin.git#30a9f504c0eda31d276f0f435ef0f95f47bdecb8",
       "requires": {
         "app-root-path": "2.0.1",
         "autoprefixer": "6.7.7",
@@ -11269,6 +11267,7 @@
         "terra-spacer": "1.0.0",
         "terra-status": "1.16.0",
         "terra-table": "1.17.0",
+        "terra-tabs": "1.0.0",
         "terra-text": "1.14.0",
         "terra-time-input": "1.15.0",
         "terra-toggle": "1.13.0",
@@ -11417,6 +11416,146 @@
         "prop-types": "15.6.0",
         "terra-base": "2.8.0",
         "terra-icon": "1.15.0"
+      }
+    },
+    "terra-tabs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/terra-tabs/-/terra-tabs-1.0.0.tgz",
+      "integrity": "sha512-yUX3UiyYSCTscxB1iqUKZFf9yIPOnFghn4oGsiep6TS5nEsYyia+QM/nkuAMK3jEOk2YQ1ZI1Evv2YmpKnUvTQ==",
+      "requires": {
+        "classnames": "2.2.5",
+        "prop-types": "15.6.0",
+        "resize-observer-polyfill": "1.5.0",
+        "terra-base": "2.9.0",
+        "terra-content-container": "1.14.0",
+        "terra-icon": "1.16.0",
+        "terra-menu": "1.11.0",
+        "terra-responsive-element": "1.14.0"
+      },
+      "dependencies": {
+        "terra-arrange": {
+          "version": "1.17.0",
+          "resolved": "https://registry.npmjs.org/terra-arrange/-/terra-arrange-1.17.0.tgz",
+          "integrity": "sha512-JsVECgRHn6NKgiYZ95zAnbEw4eybFK0SoNBOC74KP9RAYRfA/W9HUePBqr8i5wOzIyuVb2C7c4uRfx/ToBACZw==",
+          "requires": {
+            "classnames": "2.2.5",
+            "prop-types": "15.6.0",
+            "terra-base": "2.9.0"
+          }
+        },
+        "terra-base": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/terra-base/-/terra-base-2.9.0.tgz",
+          "integrity": "sha512-it0W44F91u9gyJSPtYNOBFZvh1rdQ1H7rJFK5p6ArSxIj6bx2BttRKwZl4NYyUDFaILw9NsXqxVs+NEOOVJr6Q==",
+          "requires": {
+            "classnames": "2.2.5",
+            "prop-types": "15.6.0",
+            "terra-i18n": "1.12.0",
+            "terra-mixins": "1.12.0"
+          }
+        },
+        "terra-content-container": {
+          "version": "1.14.0",
+          "resolved": "https://registry.npmjs.org/terra-content-container/-/terra-content-container-1.14.0.tgz",
+          "integrity": "sha512-7ZYdbEMStlH5b2oqBIXJryPx6MppDAaBfr77NC+vUF0UdPdfHTHc1f9helomeB4+u5Q5yzNp70vfgBoqfBrdNw==",
+          "requires": {
+            "classnames": "2.2.5",
+            "prop-types": "15.6.0",
+            "terra-base": "2.9.0"
+          }
+        },
+        "terra-hookshot": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/terra-hookshot/-/terra-hookshot-1.6.0.tgz",
+          "integrity": "sha512-MZA8LnY997h0Vnp+88fqXAU2yehxcjZz+9MQc+m33GxOzB1Ju2/B9YYRoxHH15KTLPAt30/8nG2/OzqUa14hwQ==",
+          "requires": {
+            "classnames": "2.2.5",
+            "prop-types": "15.6.0",
+            "react-onclickoutside": "5.11.1",
+            "react-portal": "3.2.0",
+            "resize-observer-polyfill": "1.5.0",
+            "terra-base": "2.9.0"
+          }
+        },
+        "terra-icon": {
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/terra-icon/-/terra-icon-1.16.0.tgz",
+          "integrity": "sha512-UX78+/erGf6NRXzCHr+lof+Eh4EmmJkPxl4EeFtE54SwVPDw5OOWHI++Khfss8rHZgbU4DUgxSpQJte7kgAyFg==",
+          "requires": {
+            "classnames": "2.2.5",
+            "prop-types": "15.6.0",
+            "terra-base": "2.9.0"
+          }
+        },
+        "terra-list": {
+          "version": "1.18.0",
+          "resolved": "https://registry.npmjs.org/terra-list/-/terra-list-1.18.0.tgz",
+          "integrity": "sha512-WyzWcniEH+KDZgt6XsxdbT3NeAdSCCrNpmayPZi0RW8OFXBnYC3zpBBfv1TQ0M1CXV77RMEzQku2YaM1CYeEcQ==",
+          "requires": {
+            "classnames": "2.2.5",
+            "prop-types": "15.6.0",
+            "terra-arrange": "1.17.0",
+            "terra-base": "2.9.0",
+            "terra-icon": "1.16.0"
+          }
+        },
+        "terra-menu": {
+          "version": "1.11.0",
+          "resolved": "https://registry.npmjs.org/terra-menu/-/terra-menu-1.11.0.tgz",
+          "integrity": "sha512-KVj3qNr4m7FZJWpXgEByFhaxuKdqqCPe7sqJp0q1xbL6vYckh03mEdjNpbsZfLFI+02hHJUn7MGBeQXzm+fngw==",
+          "requires": {
+            "classnames": "2.2.5",
+            "prop-types": "15.6.0",
+            "terra-arrange": "1.17.0",
+            "terra-base": "2.9.0",
+            "terra-content-container": "1.14.0",
+            "terra-icon": "1.16.0",
+            "terra-list": "1.18.0",
+            "terra-popup": "1.18.0",
+            "terra-slide-group": "1.14.0"
+          }
+        },
+        "terra-mixins": {
+          "version": "1.12.0",
+          "resolved": "https://registry.npmjs.org/terra-mixins/-/terra-mixins-1.12.0.tgz",
+          "integrity": "sha512-JkSjMo7l+ZavkgVqbglwMXs9OhVXf9NIjp8OrlelOscN3AC9o8U7BOUIoNCIwIMD1OvqwK2bTZ4E5Ji2NEXKkw=="
+        },
+        "terra-popup": {
+          "version": "1.18.0",
+          "resolved": "https://registry.npmjs.org/terra-popup/-/terra-popup-1.18.0.tgz",
+          "integrity": "sha512-JjXm7QHwt/stIuab7Hkk3Tpi6kot0RQy+LHh/lixRPTrTt+j9KHqIA5XB8vmWvUu8/Ttbeo5B2y5u5zSITZHkg==",
+          "requires": {
+            "classnames": "2.2.5",
+            "focus-trap-react": "3.1.0",
+            "prop-types": "15.6.0",
+            "react-portal": "3.2.0",
+            "terra-base": "2.9.0",
+            "terra-content-container": "1.14.0",
+            "terra-hookshot": "1.6.0",
+            "terra-icon": "1.16.0"
+          }
+        },
+        "terra-responsive-element": {
+          "version": "1.14.0",
+          "resolved": "https://registry.npmjs.org/terra-responsive-element/-/terra-responsive-element-1.14.0.tgz",
+          "integrity": "sha512-zkpVmONUxr0oce7ifdPuzfzQejvLNcrqNYxa28XZcHOOT3TwEmHx6o5nbWpNv2moLzUdPyrIyaIDrFNlA4FX7A==",
+          "requires": {
+            "prop-types": "15.6.0",
+            "resize-observer-polyfill": "1.5.0",
+            "terra-base": "2.9.0"
+          }
+        },
+        "terra-slide-group": {
+          "version": "1.14.0",
+          "resolved": "https://registry.npmjs.org/terra-slide-group/-/terra-slide-group-1.14.0.tgz",
+          "integrity": "sha512-dEAHIHE2Q88rZ8Fwxa1UZBrvmW4BMU9U/OW+hd8GF2o62aVfMZXkbDW5cKuNykA1Im++yypliltt33OtHHqG3g==",
+          "requires": {
+            "classnames": "2.2.5",
+            "prop-types": "15.6.0",
+            "react-transition-group": "2.2.1",
+            "terra-base": "2.9.0"
+          }
+        }
       }
     },
     "terra-text": {

--- a/node/package.json
+++ b/node/package.json
@@ -38,7 +38,7 @@
     "react-dom": "^15.6.2",
     "request": "^2.83.0",
     "request-promise": "^4.2.2",
-    "terra-kaiju-plugin": "git+https://github.com/cerner/terra-kaiju-plugin.git#Tabs",
+    "terra-kaiju-plugin": "0.4.0",
     "webpack": "^3.6.0"
   },
   "devDependencies": {

--- a/node/package.json
+++ b/node/package.json
@@ -38,7 +38,7 @@
     "react-dom": "^15.6.2",
     "request": "^2.83.0",
     "request-promise": "^4.2.2",
-    "terra-kaiju-plugin": "0.3.0",
+    "terra-kaiju-plugin": "git+https://github.com/cerner/terra-kaiju-plugin.git#Tabs",
     "webpack": "^3.6.0"
   },
   "devDependencies": {

--- a/rails/client/app/bundles/kaiju/components/Component/components/Element/Element.jsx
+++ b/rails/client/app/bundles/kaiju/components/Component/components/Element/Element.jsx
@@ -36,7 +36,9 @@ class Element extends React.Component {
   }
 
   handleClick(event) {
-    event.stopPropagation();
+    if (event.defaultPrevented) { return; }
+
+    event.preventDefault();
     window.postMessage({ message: 'kaiju-select', id: this.props.kaijuId }, '*');
     window.parent.postMessage({ message: 'kaiju-component-selected', id: this.props.kaijuId }, '*');
   }

--- a/rails/client/app/bundles/kaiju/components/Component/reducers/reducers.js
+++ b/rails/client/app/bundles/kaiju/components/Component/reducers/reducers.js
@@ -1,10 +1,12 @@
 import { combineReducers } from 'redux';
 import components from './components';
 import selectedComponent from './selectedComponent';
+import refreshedComponent from './refreshedComponent';
 
 const reducers = combineReducers({
   components,
   selectedComponent,
+  refreshedComponent,
 });
 
 export default reducers;

--- a/rails/client/app/bundles/kaiju/components/Component/reducers/refreshedComponent.js
+++ b/rails/client/app/bundles/kaiju/components/Component/reducers/refreshedComponent.js
@@ -1,0 +1,14 @@
+import { REFRESH_STORE, SELECT_COMPONENT } from '../actions/actions';
+
+const refreshedComponent = (state = null, { type, id }) => {
+  switch (type) {
+    case SELECT_COMPONENT:
+      return null;
+    case REFRESH_STORE:
+      return id;
+    default:
+      return state;
+  }
+};
+
+export default refreshedComponent;

--- a/rails/client/package-lock.json
+++ b/rails/client/package-lock.json
@@ -6244,6 +6244,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.1.0.tgz",
       "integrity": "sha1-thTJcgvmgW6u41+zpfqh26agXds=",
+      "dev": true,
       "requires": {
         "postcss": "6.0.14"
       },
@@ -6252,6 +6253,7 @@
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
           "requires": {
             "color-convert": "1.9.1"
           }
@@ -6260,6 +6262,7 @@
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
           "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
@@ -6269,12 +6272,14 @@
         "has-flag": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
         },
         "postcss": {
           "version": "6.0.14",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
           "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
+          "dev": true,
           "requires": {
             "chalk": "2.3.0",
             "source-map": "0.6.1",
@@ -6284,12 +6289,14 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
         },
         "supports-color": {
           "version": "4.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
           "requires": {
             "has-flag": "2.0.0"
           }
@@ -9914,9 +9921,7 @@
       }
     },
     "terra-kaiju-plugin": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/terra-kaiju-plugin/-/terra-kaiju-plugin-0.3.0.tgz",
-      "integrity": "sha512-QSrCRRxUKuehK8GgrGz90PpmBi9J83ztLDexw6fZEWcWLbwz57JmRy+1U3D4tRcfuFTCtNmXl5UknuBGHMNJXw==",
+      "version": "git+https://github.com/cerner/terra-kaiju-plugin.git#636ce9806645fa3cc8417cbd98df1371439cf532",
       "requires": {
         "app-root-path": "2.0.1",
         "autoprefixer": "6.7.7",
@@ -9926,7 +9931,7 @@
         "babel-plugin-transform-react-jsx": "6.24.1",
         "babel-preset-es2015": "6.24.1",
         "babel-preset-react": "6.24.1",
-        "css-loader": "0.28.8",
+        "css-loader": "0.28.9",
         "js-string-escape": "1.0.1",
         "kaiju-plugin-utils": "0.1.0",
         "node-sass": "4.7.2",
@@ -9977,12 +9982,21 @@
         "terra-spacer": "1.0.0",
         "terra-status": "1.16.0",
         "terra-table": "1.17.0",
+        "terra-tabs": "1.0.0",
         "terra-text": "1.14.0",
         "terra-time-input": "1.15.0",
         "terra-toggle": "1.13.0",
         "terra-toggle-button": "1.16.0"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
         "babel-loader": {
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-7.1.2.tgz",
@@ -9993,10 +10007,30 @@
             "mkdirp": "0.5.1"
           }
         },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "4.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+              "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+              "requires": {
+                "has-flag": "2.0.0"
+              }
+            }
+          }
+        },
         "css-loader": {
-          "version": "0.28.8",
-          "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.28.8.tgz",
-          "integrity": "sha512-4jGj7Ag6WUZ5lQyE4te9sJLn0lgkz6HI3WDE4aw98AkW1IAKXPP4blTpPeorlLDpNsYvojo0SYgRJOdz2KbuAw==",
+          "version": "0.28.9",
+          "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.28.9.tgz",
+          "integrity": "sha512-r3dgelMm/mkPz5Y7m9SeiGE46i2VsEU/OYbez+1llfxtv8b2y5/b5StaeEvPK3S5tlNQI+tDW/xDIhKJoZgDtw==",
           "requires": {
             "babel-code-frame": "6.26.0",
             "css-selector-tokenizer": "0.7.0",
@@ -10006,7 +10040,7 @@
             "lodash.camelcase": "4.3.0",
             "object-assign": "4.1.1",
             "postcss": "5.2.18",
-            "postcss-modules-extract-imports": "1.1.0",
+            "postcss-modules-extract-imports": "1.2.0",
             "postcss-modules-local-by-default": "1.2.0",
             "postcss-modules-scope": "1.1.0",
             "postcss-modules-values": "1.3.0",
@@ -10032,6 +10066,11 @@
             "locate-path": "2.0.0"
           }
         },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+        },
         "loader-utils": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
@@ -10055,6 +10094,26 @@
             "find-up": "2.1.0"
           }
         },
+        "postcss-modules-extract-imports": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.2.0.tgz",
+          "integrity": "sha1-ZhQOzs447wa/DT41XWm/WdFB6oU=",
+          "requires": {
+            "postcss": "6.0.16"
+          },
+          "dependencies": {
+            "postcss": {
+              "version": "6.0.16",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.16.tgz",
+              "integrity": "sha512-m758RWPmSjFH/2MyyG3UOW1fgYbR9rtdzz5UNJnlm7OLtu4B2h9C6gi+bE4qFKghsBRFfZT8NzoQBs6JhLotoA==",
+              "requires": {
+                "chalk": "2.3.0",
+                "source-map": "0.6.1",
+                "supports-color": "5.1.0"
+              }
+            }
+          }
+        },
         "sass-loader": {
           "version": "6.0.6",
           "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-6.0.6.tgz",
@@ -10071,6 +10130,19 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
           "integrity": "sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A=="
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        },
+        "supports-color": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
+          "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
+          "requires": {
+            "has-flag": "2.0.0"
+          }
         },
         "terra-i18n-plugin": {
           "version": "1.9.0",
@@ -10226,6 +10298,146 @@
         "prop-types": "15.6.0",
         "terra-base": "2.8.0",
         "terra-icon": "1.15.0"
+      }
+    },
+    "terra-tabs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/terra-tabs/-/terra-tabs-1.0.0.tgz",
+      "integrity": "sha512-yUX3UiyYSCTscxB1iqUKZFf9yIPOnFghn4oGsiep6TS5nEsYyia+QM/nkuAMK3jEOk2YQ1ZI1Evv2YmpKnUvTQ==",
+      "requires": {
+        "classnames": "2.2.5",
+        "prop-types": "15.6.0",
+        "resize-observer-polyfill": "1.5.0",
+        "terra-base": "2.9.0",
+        "terra-content-container": "1.14.0",
+        "terra-icon": "1.16.0",
+        "terra-menu": "1.11.0",
+        "terra-responsive-element": "1.14.0"
+      },
+      "dependencies": {
+        "terra-arrange": {
+          "version": "1.17.0",
+          "resolved": "https://registry.npmjs.org/terra-arrange/-/terra-arrange-1.17.0.tgz",
+          "integrity": "sha512-JsVECgRHn6NKgiYZ95zAnbEw4eybFK0SoNBOC74KP9RAYRfA/W9HUePBqr8i5wOzIyuVb2C7c4uRfx/ToBACZw==",
+          "requires": {
+            "classnames": "2.2.5",
+            "prop-types": "15.6.0",
+            "terra-base": "2.9.0"
+          }
+        },
+        "terra-base": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/terra-base/-/terra-base-2.9.0.tgz",
+          "integrity": "sha512-it0W44F91u9gyJSPtYNOBFZvh1rdQ1H7rJFK5p6ArSxIj6bx2BttRKwZl4NYyUDFaILw9NsXqxVs+NEOOVJr6Q==",
+          "requires": {
+            "classnames": "2.2.5",
+            "prop-types": "15.6.0",
+            "terra-i18n": "1.12.0",
+            "terra-mixins": "1.12.0"
+          }
+        },
+        "terra-content-container": {
+          "version": "1.14.0",
+          "resolved": "https://registry.npmjs.org/terra-content-container/-/terra-content-container-1.14.0.tgz",
+          "integrity": "sha512-7ZYdbEMStlH5b2oqBIXJryPx6MppDAaBfr77NC+vUF0UdPdfHTHc1f9helomeB4+u5Q5yzNp70vfgBoqfBrdNw==",
+          "requires": {
+            "classnames": "2.2.5",
+            "prop-types": "15.6.0",
+            "terra-base": "2.9.0"
+          }
+        },
+        "terra-hookshot": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/terra-hookshot/-/terra-hookshot-1.6.0.tgz",
+          "integrity": "sha512-MZA8LnY997h0Vnp+88fqXAU2yehxcjZz+9MQc+m33GxOzB1Ju2/B9YYRoxHH15KTLPAt30/8nG2/OzqUa14hwQ==",
+          "requires": {
+            "classnames": "2.2.5",
+            "prop-types": "15.6.0",
+            "react-onclickoutside": "5.11.1",
+            "react-portal": "3.2.0",
+            "resize-observer-polyfill": "1.5.0",
+            "terra-base": "2.9.0"
+          }
+        },
+        "terra-icon": {
+          "version": "1.16.0",
+          "resolved": "https://registry.npmjs.org/terra-icon/-/terra-icon-1.16.0.tgz",
+          "integrity": "sha512-UX78+/erGf6NRXzCHr+lof+Eh4EmmJkPxl4EeFtE54SwVPDw5OOWHI++Khfss8rHZgbU4DUgxSpQJte7kgAyFg==",
+          "requires": {
+            "classnames": "2.2.5",
+            "prop-types": "15.6.0",
+            "terra-base": "2.9.0"
+          }
+        },
+        "terra-list": {
+          "version": "1.18.0",
+          "resolved": "https://registry.npmjs.org/terra-list/-/terra-list-1.18.0.tgz",
+          "integrity": "sha512-WyzWcniEH+KDZgt6XsxdbT3NeAdSCCrNpmayPZi0RW8OFXBnYC3zpBBfv1TQ0M1CXV77RMEzQku2YaM1CYeEcQ==",
+          "requires": {
+            "classnames": "2.2.5",
+            "prop-types": "15.6.0",
+            "terra-arrange": "1.17.0",
+            "terra-base": "2.9.0",
+            "terra-icon": "1.16.0"
+          }
+        },
+        "terra-menu": {
+          "version": "1.11.0",
+          "resolved": "https://registry.npmjs.org/terra-menu/-/terra-menu-1.11.0.tgz",
+          "integrity": "sha512-KVj3qNr4m7FZJWpXgEByFhaxuKdqqCPe7sqJp0q1xbL6vYckh03mEdjNpbsZfLFI+02hHJUn7MGBeQXzm+fngw==",
+          "requires": {
+            "classnames": "2.2.5",
+            "prop-types": "15.6.0",
+            "terra-arrange": "1.17.0",
+            "terra-base": "2.9.0",
+            "terra-content-container": "1.14.0",
+            "terra-icon": "1.16.0",
+            "terra-list": "1.18.0",
+            "terra-popup": "1.18.0",
+            "terra-slide-group": "1.14.0"
+          }
+        },
+        "terra-mixins": {
+          "version": "1.12.0",
+          "resolved": "https://registry.npmjs.org/terra-mixins/-/terra-mixins-1.12.0.tgz",
+          "integrity": "sha512-JkSjMo7l+ZavkgVqbglwMXs9OhVXf9NIjp8OrlelOscN3AC9o8U7BOUIoNCIwIMD1OvqwK2bTZ4E5Ji2NEXKkw=="
+        },
+        "terra-popup": {
+          "version": "1.18.0",
+          "resolved": "https://registry.npmjs.org/terra-popup/-/terra-popup-1.18.0.tgz",
+          "integrity": "sha512-JjXm7QHwt/stIuab7Hkk3Tpi6kot0RQy+LHh/lixRPTrTt+j9KHqIA5XB8vmWvUu8/Ttbeo5B2y5u5zSITZHkg==",
+          "requires": {
+            "classnames": "2.2.5",
+            "focus-trap-react": "3.0.5",
+            "prop-types": "15.6.0",
+            "react-portal": "3.2.0",
+            "terra-base": "2.9.0",
+            "terra-content-container": "1.14.0",
+            "terra-hookshot": "1.6.0",
+            "terra-icon": "1.16.0"
+          }
+        },
+        "terra-responsive-element": {
+          "version": "1.14.0",
+          "resolved": "https://registry.npmjs.org/terra-responsive-element/-/terra-responsive-element-1.14.0.tgz",
+          "integrity": "sha512-zkpVmONUxr0oce7ifdPuzfzQejvLNcrqNYxa28XZcHOOT3TwEmHx6o5nbWpNv2moLzUdPyrIyaIDrFNlA4FX7A==",
+          "requires": {
+            "prop-types": "15.6.0",
+            "resize-observer-polyfill": "1.5.0",
+            "terra-base": "2.9.0"
+          }
+        },
+        "terra-slide-group": {
+          "version": "1.14.0",
+          "resolved": "https://registry.npmjs.org/terra-slide-group/-/terra-slide-group-1.14.0.tgz",
+          "integrity": "sha512-dEAHIHE2Q88rZ8Fwxa1UZBrvmW4BMU9U/OW+hd8GF2o62aVfMZXkbDW5cKuNykA1Im++yypliltt33OtHHqG3g==",
+          "requires": {
+            "classnames": "2.2.5",
+            "prop-types": "15.6.0",
+            "react-transition-group": "2.2.1",
+            "terra-base": "2.9.0"
+          }
+        }
       }
     },
     "terra-text": {

--- a/rails/client/package-lock.json
+++ b/rails/client/package-lock.json
@@ -9921,7 +9921,9 @@
       }
     },
     "terra-kaiju-plugin": {
-      "version": "git+https://github.com/cerner/terra-kaiju-plugin.git#30a9f504c0eda31d276f0f435ef0f95f47bdecb8",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/terra-kaiju-plugin/-/terra-kaiju-plugin-0.4.0.tgz",
+      "integrity": "sha512-zp3sDnXmH7hbcv9LI7ngllLRoSXOK9tDixNMwd1NtSjMrpyjUbZDiJF45CHx8ajZIiD5j2k9R1dPtgJrIClnYA==",
       "requires": {
         "app-root-path": "2.0.1",
         "autoprefixer": "6.7.7",

--- a/rails/client/package-lock.json
+++ b/rails/client/package-lock.json
@@ -9921,7 +9921,7 @@
       }
     },
     "terra-kaiju-plugin": {
-      "version": "git+https://github.com/cerner/terra-kaiju-plugin.git#636ce9806645fa3cc8417cbd98df1371439cf532",
+      "version": "git+https://github.com/cerner/terra-kaiju-plugin.git#30a9f504c0eda31d276f0f435ef0f95f47bdecb8",
       "requires": {
         "app-root-path": "2.0.1",
         "autoprefixer": "6.7.7",

--- a/rails/client/package.json
+++ b/rails/client/package.json
@@ -34,7 +34,7 @@
     "terra-base": "^2.0.0",
     "terra-i18n": "^1.0.0",
     "terra-icon": "^1.0.0",
-    "terra-kaiju-plugin": "git+https://github.com/cerner/terra-kaiju-plugin.git#Tabs",
+    "terra-kaiju-plugin": "0.4.0",
     "terra-legacy-theme": "^1.0.0",
     "tether": "^1.4.0",
     "uniqid": "^4.1.1"

--- a/rails/client/package.json
+++ b/rails/client/package.json
@@ -34,9 +34,10 @@
     "terra-base": "^2.0.0",
     "terra-i18n": "^1.0.0",
     "terra-icon": "^1.0.0",
-    "terra-kaiju-plugin": "0.3.0",
+    "terra-kaiju-plugin": "git+https://github.com/cerner/terra-kaiju-plugin.git#Tabs",
     "terra-legacy-theme": "^1.0.0",
-    "tether": "^1.4.0"
+    "tether": "^1.4.0",
+    "uniqid": "^4.1.1"
   },
   "devDependencies": {
     "autoprefixer": "^6.6.1",


### PR DESCRIPTION
### Summary
- Pulling in Tabs
- Removed empty arrays from being passed as component props
- Conditionally force a re-render of the most recently refreshed component. This enables editing uncontrolled components and being able to see the changes without refreshing the screen.
- Enabled click propagation to allow click events to trigger default component functionality. ( Such as selecting tabs )

### Additional details 
Blocked until the code merge and release of [terra-kaiju-plugin](https://github.com/cerner/terra-kaiju-plugin/pull/5)

Thanks for contributing to Kaiju.
@cerner/kaiju

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
