### PR TITLE
[do-not-merge] Updated - Lazy load components

### DIFF
--- a/rails/app/controllers/components_controller.rb
+++ b/rails/app/controllers/components_controller.rb
@@ -4,19 +4,19 @@ class ComponentsController < ApplicationController
   before_action { fetch_component(params[:id]) }
   before_action(only: %i[show]) { current_user.add_recent_workspace(params[:project_id], params[:workspace_id]) }
   before_action(except: %i[show attributes]) { authorize(params[:workspace_object].editors) }
+
   # GET /projects/1/workspaces/1/components/1
   def show # rubocop:disable Metrics/AbcSize
     # Rails.logger.debug params
     component = params[:component_object]
-
-    @component = Kaiju::ComponentJson.as_json(
-      component.id, request.base_url,
-      project_id: params[:project_id], workspace_id: params[:workspace_id], user_id: current_user.id
-    )
+    options = { project_id: params[:project_id], workspace_id: params[:workspace_id], user_id: current_user.id }
 
     respond_to do |format|
-      format.html
-      format.json { render json: JSON.pretty_generate(@component) }
+      format.html { @component = Kaiju::ComponentJson.as_json_lite(component.id, request.base_url, options) }
+      format.json do |_json|
+        @component = Kaiju::ComponentJson.as_json(component.id, request.base_url, options)
+        render json: JSON.pretty_generate(@component)
+      end
     end
   end
 

--- a/rails/client/app/bundles/kaiju/components/Component/Component.jsx
+++ b/rails/client/app/bundles/kaiju/components/Component/Component.jsx
@@ -1,31 +1,59 @@
 import React from 'react';
 import Base from 'terra-base';
 import PropTypes from 'prop-types';
+import ajax from 'superagent';
+import classNames from 'classnames/bind';
 import { Provider } from 'react-redux';
 import configureStore from './store/componentStore';
 import ComponentContainer from './containers/ComponentContainer';
+import Spinner from '../common/Spinner/Spinner';
 import distpatcher from './utilities/dispatcher';
 import initializeDrag from './utilities/drag';
+import styles from './Component.scss';
+
+const cx = classNames.bind(styles);
 
 const propTypes = {
   /**
-   * The Component Identifer
+   * The Component identifer.
    */
   id: PropTypes.string.isRequired,
+  /**
+   * The Component url.
+   */
+  url: PropTypes.string.isRequired,
 };
 
 class Component extends React.Component {
   constructor(props) {
     super(props);
-    this.store = configureStore(this.props);
+
+    this.state = { loading: true };
   }
 
   componentDidMount() {
-    distpatcher(this.store, this.props.id);
     initializeDrag();
+
+    this.request = ajax
+      .get(this.props.url)
+      .set('Accept', 'application/json')
+      .end((error, response) => {
+        if (response) {
+          const component = JSON.parse(response.text);
+
+          this.store = configureStore(component);
+          distpatcher(this.store, this.props.id);
+
+          this.setState({ loading: false });
+        }
+      });
   }
 
   render() {
+    if (this.state.loading) {
+      return <div className={cx('loading')}><Spinner /></div>;
+    }
+
     return (
       <Provider store={this.store}>
         <Base locale="en-US">

--- a/rails/client/app/bundles/kaiju/components/Component/Component.scss
+++ b/rails/client/app/bundles/kaiju/components/Component/Component.scss
@@ -1,0 +1,8 @@
+:local {
+  .loading {
+    align-items: center;
+    display: flex;
+    height: 100%;
+    justify-content: center;
+  }
+}


### PR DESCRIPTION
### Summary
This is a proof of concept to lazy load components within the workspace. Lazy loading provides an opportunity for displaying a loading indicator as the service fetches data. 

![loading](https://user-images.githubusercontent.com/6720991/35205276-7e6744d0-fef9-11e7-8b19-ef4a2f62458f.gif)

### Additional Details
This pull request updates the components html #show to fetch the lite JSON response. When the page loads it will display a loading indicator and then fetch the full component JSON.

### Issues
There is currently an issue with pulling in the ant spinner which will import global reset styles, this can be easily resolved by using a custom spinner or a loading indicator provided by Terra.

Thanks for contributing to Kaiju.
@cerner/kaiju

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
