### PR TITLE
[do-not-merge] Added - A keyboard shortcut for duplicate and cmd+click for selecting a parent component

### DIFF
--- a/rails/client/app/bundles/kaiju/components/Component/components/Element/Element.jsx
+++ b/rails/client/app/bundles/kaiju/components/Component/components/Element/Element.jsx
@@ -36,11 +36,11 @@ class Element extends React.Component {
   }
 
   handleClick(event) {
-    if (event.defaultPrevented) { return; }
-
-    event.preventDefault();
-    window.postMessage({ message: 'kaiju-select', id: this.props.kaijuId }, '*');
-    window.parent.postMessage({ message: 'kaiju-component-selected', id: this.props.kaijuId }, '*');
+    // if (event.defaultPrevented) { return; }
+    //
+    // event.preventDefault();
+    // window.postMessage({ message: 'kaiju-select', id: this.props.kaijuId }, '*');
+    // window.parent.postMessage({ message: 'kaiju-component-selected', id: this.props.kaijuId }, '*');
   }
 
   register() {

--- a/rails/client/app/bundles/kaiju/components/Component/utilities/dispatcher.js
+++ b/rails/client/app/bundles/kaiju/components/Component/utilities/dispatcher.js
@@ -334,6 +334,51 @@ const registerDispatcher = (store, root) => {
     duplicate(getSelectedComponent());
   });
   window.addEventListener('message', dispatchMessage);
+
+  const find = (start) => {
+    let target = start;
+    while (target.hasAttribute('data-kaiju-component-id') === false) {
+      if (target === document.body) {
+        return null;
+      }
+      target = target.parentNode;
+    }
+    return target;
+  };
+
+  const isInsideSelected = ({ clientX, clientY }) => {
+    const selectedComponent = document.querySelectorAll(`[data-kaiju-component-id="${getSelectedComponent()}"]`)[0];
+
+    if (!selectedComponent) {
+      return false;
+    }
+
+    const { left, right, top, bottom } = selectedComponent.getBoundingClientRect();
+
+    if (clientX >= left && clientX <= right && clientY >= top && clientY <= bottom) {
+      return true;
+    }
+
+    return false;
+  };
+
+  const selectTarget = (event) => {
+    if ((event.ctrlKey || event.metaKey) && isInsideSelected(event)) {
+      const selectedComponent = fetch(getSelectedComponent());
+      const id = selectedComponent.parent || selectedComponent.id;
+      select(id);
+      post({ message: 'kaiju-component-selected', id }, '*');
+    } else {
+      const target = find(event.target);
+      const id = target.getAttribute('data-kaiju-component-id');
+      //
+      select(id);
+      post({ message: 'kaiju-component-selected', id }, '*');
+    }
+  };
+
+  // Hack for example click traversal
+  window.addEventListener('click', selectTarget);
 };
 
 export default registerDispatcher;

--- a/rails/client/app/bundles/kaiju/components/Component/utilities/dispatcher.js
+++ b/rails/client/app/bundles/kaiju/components/Component/utilities/dispatcher.js
@@ -295,7 +295,7 @@ const registerDispatcher = (store, root) => {
     if (message === 'kaiju-destroy') {
       destroy(id || getSelectedComponent());
     } else if (message === 'kaiju-duplicate') {
-      duplicate(id);
+      duplicate(id || getSelectedComponent());
     } else if (message === 'kaiju-duplicate-property') {
       duplicateProperty(id, data.property);
     } else if (message === 'kaiju-insert') {
@@ -324,11 +324,15 @@ const registerDispatcher = (store, root) => {
 
   postUpdate();
   Mousetrap.bind(['esc'], () => select(null));
-  Mousetrap.bind(['backspace', 'delete'], () => destroy(getSelectedComponent()));
   Mousetrap.bind(['command+c', 'ctrl+c'], copy);
   Mousetrap.bind(['command+v', 'ctrl+v'], paste);
   Mousetrap.bind(['command+z', 'ctrl+z'], undo);
   Mousetrap.bind(['command+shift+z', 'ctrl+shift+z'], redo);
+  Mousetrap.bind(['backspace', 'delete'], () => destroy(getSelectedComponent()));
+  Mousetrap.bind(['command+d', 'ctrl+d'], (event) => {
+    event.preventDefault();
+    duplicate(getSelectedComponent());
+  });
   window.addEventListener('message', dispatchMessage);
 };
 

--- a/rails/client/app/bundles/kaiju/components/Component/utilities/overlay.js
+++ b/rails/client/app/bundles/kaiju/components/Component/utilities/overlay.js
@@ -112,7 +112,6 @@ const addParentOverlay = (node) => {
   addOverlay(target);
 };
 
-
 // Redraw the Overlay during any window resize events
 window.addEventListener('resize', () => {
   clearTimeout(resizeTimer);

--- a/rails/client/app/bundles/kaiju/components/Project/components/ActionBar/ActionBar.jsx
+++ b/rails/client/app/bundles/kaiju/components/Project/components/ActionBar/ActionBar.jsx
@@ -81,7 +81,11 @@ class ActionBar extends React.Component {
 
   duplicate(event) {
     event.preventDefault();
-    duplicate(this.props.selectedComponent);
+
+    const selectedComponent = this.props.selectedComponent;
+    if (selectedComponent) {
+      duplicate(this.props.selectedComponent.id);
+    }
   }
 
   handleShortcuts({ data }) {

--- a/rails/client/app/bundles/kaiju/components/Project/components/ActionBar/ActionBar.jsx
+++ b/rails/client/app/bundles/kaiju/components/Project/components/ActionBar/ActionBar.jsx
@@ -4,7 +4,7 @@ import Mousetrap from 'mousetrap';
 import IconUndo from 'terra-icon/lib/icon/IconReply';
 import IconRedo from 'terra-icon/lib/icon/IconForward';
 import axios from '../../../../utilities/axios';
-import { copy, destroy, paste, refresh, select } from '../../utilities/messenger';
+import { copy, destroy, duplicate, paste, refresh, select } from '../../utilities/messenger';
 import ActionItem from './ActionItem/ActionItem';
 import Delete from './Delete/Delete';
 import Duplicate from '../../containers/DuplicateWorkspaceContainer';
@@ -53,6 +53,7 @@ class ActionBar extends React.Component {
     super();
     this.undo = this.undo.bind(this);
     this.redo = this.redo.bind(this);
+    this.duplicate = this.duplicate.bind(this);
     this.handleShortcuts = this.handleShortcuts.bind(this);
   }
 
@@ -61,6 +62,7 @@ class ActionBar extends React.Component {
     Mousetrap.bind(['command+v', 'ctrl+v'], paste);
     Mousetrap.bind(['command+z', 'ctrl+z'], this.undo);
     Mousetrap.bind(['command+shift+z', 'ctrl+shift+z'], this.redo);
+    Mousetrap.bind(['command+d', 'ctrl+d'], this.duplicate);
     Mousetrap.bind(['backspace', 'delete'], ActionBar.destroy);
     Mousetrap.bind(['esc'], ActionBar.deselect);
     window.addEventListener('message', this.handleShortcuts);
@@ -71,9 +73,15 @@ class ActionBar extends React.Component {
     Mousetrap.unbind(['command+v', 'ctrl+v'], paste);
     Mousetrap.unbind(['command+z', 'ctrl+z'], this.undo);
     Mousetrap.unbind(['command+shift+z', 'ctrl+shift+z'], this.redo);
+    Mousetrap.unbind(['command+d', 'ctrl+d'], this.duplicate);
     Mousetrap.unbind(['backspace', 'delete'], ActionBar.destroy);
     Mousetrap.unbind(['esc'], ActionBar.deselect);
     window.removeEventListener('message', this.handleShortcuts);
+  }
+
+  duplicate(event) {
+    event.preventDefault();
+    duplicate(this.props.selectedComponent);
   }
 
   handleShortcuts({ data }) {
@@ -84,7 +92,11 @@ class ActionBar extends React.Component {
     }
   }
 
-  undo() {
+  undo(event) {
+    if (event) {
+      event.preventDefault();
+    }
+
     axios
      .put(this.props.workspace.undoUrl)
      .then(({ status, data }) => {


### PR DESCRIPTION
### Summary
This branch is only for a proof of concept to get feedback from designers. 

After gathering feedback from users it became noticeable the workflow to duplicate a child was a little awkward. IE: Clicking the component, navigating up to the parent, finding the child in the editor, and clicking duplicate. ( Or finding the child in the layers ) 

This feedback also indicated a difficulty navigating upwards from components.

This pull requests adds a keyboard shortcut (cmd+d / ctrl+d) that will duplicate the currently selected item, if it can be duplicated and a command click interaction that will select the parent of the currently selected component.

Thanks for contributing to Kaiju.
@cerner/kaiju

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
