### PR TITLE
Added - A keyboard shortcut for duplicating selected components

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
-## January 22nd, 2018
+## January 25th, 2018
 ### Added
-- A help guide (Accessible under the help menu dropdown)
+- [A help guide](/guide) (Accessible under the help menu dropdown)
 
 ## January 19th, 2018
 ### Added

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,7 @@
 ## January 25th, 2018
 ### Added
 - [A help guide](/guide) (Accessible under the help menu dropdown)
-- A keyboard shortcut for duplicating the selected element (ctrl+d)
+- A keyboard shortcut for duplicating the selected component (ctrl+d)
 
 ## January 19th, 2018
 ### Added

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 ## January 25th, 2018
 ### Added
 - [A help guide](/guide) (Accessible under the help menu dropdown)
+- A keyboard shortcut for duplicating the selected element (ctrl+d)
 
 ## January 19th, 2018
 ### Added

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -48,14 +48,15 @@ To send a read-only view of a workspace share the url from the browser.
 
 ### Keyboard shortcuts
 
-| Action        | Keyboard shortcut |
-| ------------- |:-----------------:|
-| Undo          | ctrl-z            |
-| Redo          | ctrl-shift-z      |
-| Copy          | ctrl-c            |
-| Paste         | ctrl-v            |
-| Deselect      | esc               |
 
+| Action        | Windows           | Mac               |
+| ------------- |-------------------|-------------------|
+| Undo          | ctrl-z            | ⌘-z               |
+| Redo          | ctrl-shift-z      | ⌘-shift-z         |
+| Copy          | ctrl-c            | ⌘-c               |
+| Paste         | ctrl-v            | ⌘-v               |
+| Duplicate     | ctrl+d            | ⌘-d               |
+| Deselect      | esc               | esc               |
 
 ## Tips and tricks
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -55,7 +55,7 @@ To send a read-only view of a workspace share the url from the browser.
 | Redo          | ctrl-shift-z      | ⌘-shift-z         |
 | Copy          | ctrl-c            | ⌘-c               |
 | Paste         | ctrl-v            | ⌘-v               |
-| Duplicate     | ctrl+d            | ⌘-d               |
+| Duplicate     | ctrl-d            | ⌘-d               |
 | Deselect      | esc               | esc               |
 
 ## Tips and tricks

--- a/rails/client/app/bundles/kaiju/components/Component/utilities/dispatcher.js
+++ b/rails/client/app/bundles/kaiju/components/Component/utilities/dispatcher.js
@@ -169,9 +169,6 @@ const registerDispatcher = (store, root) => {
     if (target.insertAfterUrl) {
       const properties = serialize(target);
       put(target.insertAfterUrl, { value: properties }, () => refresh(target.parent));
-    } else {
-      // eslint-disable-next-line no-console
-      console.warn('Non-Array Element requested duplication');
     }
   };
 
@@ -324,11 +321,12 @@ const registerDispatcher = (store, root) => {
 
   postUpdate();
   Mousetrap.bind(['esc'], () => select(null));
-  Mousetrap.bind(['backspace', 'delete'], () => destroy(getSelectedComponent()));
   Mousetrap.bind(['command+c', 'ctrl+c'], copy);
   Mousetrap.bind(['command+v', 'ctrl+v'], paste);
   Mousetrap.bind(['command+z', 'ctrl+z'], undo);
   Mousetrap.bind(['command+shift+z', 'ctrl+shift+z'], redo);
+  Mousetrap.bind(['backspace', 'delete'], () => destroy(getSelectedComponent()));
+  Mousetrap.bind(['command+d', 'ctrl+d'], () => { duplicate(getSelectedComponent()); return false; });
   window.addEventListener('message', dispatchMessage);
 };
 

--- a/rails/client/app/bundles/kaiju/components/Project/components/ActionBar/ActionBar.jsx
+++ b/rails/client/app/bundles/kaiju/components/Project/components/ActionBar/ActionBar.jsx
@@ -4,7 +4,7 @@ import Mousetrap from 'mousetrap';
 import IconUndo from 'terra-icon/lib/icon/IconReply';
 import IconRedo from 'terra-icon/lib/icon/IconForward';
 import axios from '../../../../utilities/axios';
-import { copy, destroy, paste, refresh, select } from '../../utilities/messenger';
+import { copy, duplicate, destroy, paste, refresh, select } from '../../utilities/messenger';
 import ActionItem from './ActionItem/ActionItem';
 import Delete from './Delete/Delete';
 import Duplicate from '../../containers/DuplicateWorkspaceContainer';
@@ -53,6 +53,7 @@ class ActionBar extends React.Component {
     super();
     this.undo = this.undo.bind(this);
     this.redo = this.redo.bind(this);
+    this.duplicate = this.duplicate.bind(this);
     this.handleShortcuts = this.handleShortcuts.bind(this);
   }
 
@@ -63,6 +64,7 @@ class ActionBar extends React.Component {
     Mousetrap.bind(['command+shift+z', 'ctrl+shift+z'], this.redo);
     Mousetrap.bind(['backspace', 'delete'], ActionBar.destroy);
     Mousetrap.bind(['esc'], ActionBar.deselect);
+    Mousetrap.bind(['command+d', 'ctrl+d'], this.duplicate);
     window.addEventListener('message', this.handleShortcuts);
   }
 
@@ -73,7 +75,25 @@ class ActionBar extends React.Component {
     Mousetrap.unbind(['command+shift+z', 'ctrl+shift+z'], this.redo);
     Mousetrap.unbind(['backspace', 'delete'], ActionBar.destroy);
     Mousetrap.unbind(['esc'], ActionBar.deselect);
+    Mousetrap.unbind(['command+d', 'ctrl+d'], this.duplicate);
     window.removeEventListener('message', this.handleShortcuts);
+  }
+
+  /**
+   * Sends a request to duplicate the selected item.
+   * @return {Boolean} - False if the default action should be prevented, otherwise true.
+   */
+  duplicate() {
+    const { selectedComponent } = this.props;
+
+    if (selectedComponent) {
+      duplicate(selectedComponent.id);
+
+      // Returning false is a feature of mousetrap to prevent default actions.
+      return false;
+    }
+
+    return true;
   }
 
   handleShortcuts({ data }) {


### PR DESCRIPTION
### Summary
Added a keyboard shortcut for duplicating a selected component.

Also updated the changelog to provide a link to the newly added guide.

### Additional Details
This guide link will not work on github, but will work from the application.

Resolves: #https://github.com/cerner/kaiju/issues/78

Thanks for contributing to Kaiju.
@cerner/kaiju

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
