### PR TITLE
Added - Scaffolding for unauthorized error handling

### DIFF
--- a/rails/client/app/bundles/kaiju/components/Component/utilities/dispatcher.js
+++ b/rails/client/app/bundles/kaiju/components/Component/utilities/dispatcher.js
@@ -73,13 +73,6 @@ const registerDispatcher = (store, root) => {
   const dispatch = (action) => { store.dispatch(action); };
 
   /**
-   * Handles a server error
-   */
-  const handleError = () => {
-    window.parent.location.reload();
-  };
-
-  /**
    * Puts a request
    * @param {String} url - The request URL
    * @param {Object} data - Data to send down with the request
@@ -92,9 +85,6 @@ const registerDispatcher = (store, root) => {
         if (callback) {
           callback(response.data);
         }
-      })
-      .catch((error) => {
-        handleError(error);
       });
   };
 
@@ -124,9 +114,6 @@ const registerDispatcher = (store, root) => {
         } else {
           select(null);
         }
-      })
-      .catch((error) => {
-        handleError(error);
       });
   };
 
@@ -154,9 +141,6 @@ const registerDispatcher = (store, root) => {
       .delete(targetUrl)
       .then(() => {
         refresh(parent);
-      })
-      .catch((error) => {
-        handleError(error);
       });
   };
 
@@ -185,7 +169,6 @@ const registerDispatcher = (store, root) => {
         refresh(id);
       });
   };
-
 
   /**
    * Inserts a component before a target

--- a/rails/client/app/bundles/kaiju/utilities/axios.js
+++ b/rails/client/app/bundles/kaiju/utilities/axios.js
@@ -7,7 +7,7 @@ const getCSRFToken = () => (
   document.querySelector('meta[name="csrf-token"]').getAttribute('content')
 );
 
-export default axios.create({
+const Axios = axios.create({
   responseType: 'json',
   headers: {
     Accept: 'application/json',
@@ -19,3 +19,29 @@ export default axios.create({
     return JSON.stringify(data);
   },
 });
+
+/**
+ * Intercepts every request / reponse before then() and catch() are invoked.
+ */
+Axios.interceptors.response.use(response => response, (error) => {
+  const { response, request } = error;
+  if (response) {
+    switch (response.status) {
+      case 422: // Unprocessable entity. ( Bad token or expired cookie / session )
+      case 403: // Forbidden resource. TODO: Add visual feedback instead of hard refresh.
+      case 401: // Unauthorized.
+        (window.parent || window).location.reload();
+        return Promise.reject(error);
+      default:
+        // No default behavior
+    }
+  // The server sent no response. Most likely not connected to the internet.
+  } else if (request) {
+    (window.parent || window).location.reload();
+    return Promise.reject(error);
+  }
+
+  return error;
+});
+
+export default Axios;


### PR DESCRIPTION
### Summary
This pull requests adds the foundation for generic error handling.

The axios interceptors will intercept every request and evaluate the server response / error. If the server responds with an unauthorized status or doesn't respond at all the browser will reload the current page which will force a login.

### Additional Details
There is some consideration and discussions for future changes needed for other errors that may need to provide a user with some visual feedback. JS error, internal error, etc...

Ideally 403 errors would be prevented by safeguards in the UI. This pull request will refresh the page on forbidden requests, this should probably be handled in another way in the future. Either by preventing the action entirely in the UI or notifying the user they are not authorized to take that action. 

Thanks for contributing to Kaiju.
@cerner/kaiju

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
