### PR TITLE
Updated - Disabled collaborators check to mark the change log as read

### DIFF
--- a/rails/app/controllers/projects_controller.rb
+++ b/rails/app/controllers/projects_controller.rb
@@ -3,7 +3,9 @@ require 'component_information'
 class ProjectsController < ApplicationController
   include ::ProjectsHelper
   before_action(except: %i[index create new]) { fetch_project(params[:id]) }
-  before_action(except: %i[show index create new reference_components]) { authorize(params[:project_object].editors) }
+  before_action(except: %i[show index create new reference_components changelog_viewed]) do |_action|
+    authorize(params[:project_object].editors)
+  end
 
   # GET /projects/1
   def show # rubocop:disable Metrics/AbcSize


### PR DESCRIPTION
### Summary
When the change log is viewed the put to the server returns a 403 if the user is not a collaborator on the project.

The change log is never marked as viewed. 

Fixes #85

### Additional Details
This pull request disables the collaborators check when the change log is viewed on a read-only project.

Thanks for contributing to Kaiju.
@cerner/kaiju

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
