### PR TITLE
Fixed - Workspace resizing

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+## February 1st, 2018
+### Fixed
+- Workspace resizing to enable larger breakpoint resizes
+
 ## January 28th, 2018
 ### Added
 - Clicking a selected component while holding ctrl/cmd will select the parent

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 ## February 1st, 2018
 ### Fixed
-- Workspace resizing to enable larger breakpoint resizes
+- Workspaces can be resized to any breakpoint regardless of screen size
 
 ## January 28th, 2018
 ### Added

--- a/rails/client/app/bundles/kaiju/components/Project/components/Sandbox/Sandbox.jsx
+++ b/rails/client/app/bundles/kaiju/components/Project/components/Sandbox/Sandbox.jsx
@@ -53,12 +53,14 @@ class Sandbox extends React.Component {
       <div className={cx('sandbox')}>
         { !workspace.isEditable && <Alert title="Read-only view." description="You are not authorized to edit this workspace." /> }
         <div className={cx('content')}>
-          <iframe
-            id="kaiju-Sandbox-iframe"
-            className={cx('iframe', canvasSize)}
-            src={workspace.component.url}
-            title="sandbox"
-          />
+          <div className={cx('container')}>
+            <iframe
+              id="kaiju-Sandbox-iframe"
+              className={cx('iframe', canvasSize)}
+              src={workspace.component.url}
+              title="sandbox"
+            />
+          </div>
           <ActionBar
             canvasSize={canvasSize}
             onDelete={onDelete}

--- a/rails/client/app/bundles/kaiju/components/Project/components/Sandbox/Sandbox.scss
+++ b/rails/client/app/bundles/kaiju/components/Project/components/Sandbox/Sandbox.scss
@@ -6,6 +6,14 @@
     padding: 20px 20px 0;
   }
 
+  .container {
+    display: flex;
+    flex: auto;
+    justify-content: center;
+    overflow: auto;
+    position: relative;
+  }
+
   .sandbox {
     display: flex;
     flex: auto;
@@ -17,10 +25,11 @@
     border: 0;
     box-shadow: 0 0 10px 0 #000;
     flex: auto;
-    margin: 0 auto;
-    max-width: 100%;
-    min-height: 0;
-    overflow: auto;
+    height: 100%;
+    left: 0;
+    margin: auto;
+    position: absolute;
+    right: 0;
     transition: width 0.5s ease-in-out;
     width: 100%;
   }


### PR DESCRIPTION
### Summary
Workspaces were unable to be resized larger than the available screen size. This fix enables an overflow so workspaces can be resized to all breakpoints regardless of screen size.

Fixes https://github.com/cerner/kaiju/issues/90

Thanks for contributing to Kaiju.
@cerner/kaiju

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
