### PR TITLE
[do-not-merge] Added - Icon previews

### DIFF
--- a/rails/client/app/bundles/kaiju/components/Project/components/DraggableItem/DraggableItem.jsx
+++ b/rails/client/app/bundles/kaiju/components/Project/components/DraggableItem/DraggableItem.jsx
@@ -1,24 +1,28 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames/bind';
+import iconMap from 'terra-kaiju-plugin/iconMap';
 import { Icon, Tooltip } from 'antd';
 import { select } from '../../utilities/messenger';
-import './DraggableItem.scss';
+import styles from './DraggableItem.scss';
+
+const cx = classNames.bind(styles);
 
 const propTypes = {
   /**
-   * Description text
+   * Description text.
    */
   description: PropTypes.string,
   /**
-   * Display text
+   * Display text.
    */
   display: PropTypes.string,
   /**
-   * The component library
+   * The component library.
    */
   library: PropTypes.string,
   /**
-   * The component name
+   * The component name.
    */
   name: PropTypes.string,
 };
@@ -32,12 +36,14 @@ const DraggableItem = ({ display, description, library, name }) => {
     event.dataTransfer.setData('text', JSON.stringify({ type: `${library}::${name}` }));
   }
 
+  const IconType = iconMap[`${library}::${name}`];
+
   return (
-    <li className="kaiju-DraggableItem" draggable onDragStart={handleDragStart}>
-      <span className="kaiju-DraggableItem-text">
-        {display}
+    <li className={cx('item')} draggable onDragStart={handleDragStart}>
+      <span className={cx('display')}>
+        {IconType && <IconType className={cx('icon')} />}{display}
       </span>
-      <span className="kaiju-DraggableItem-description">
+      <span className={cx('description')}>
         <Tooltip placement="right" title={description}>
           <Icon type="question-circle-o" />
         </Tooltip>

--- a/rails/client/app/bundles/kaiju/components/Project/components/DraggableItem/DraggableItem.scss
+++ b/rails/client/app/bundles/kaiju/components/Project/components/DraggableItem/DraggableItem.scss
@@ -1,36 +1,29 @@
-.kaiju-DraggableItem {
-  color: #bbb;
-  cursor: grab;
-  display: flex;
-  flex: 0 0 auto;
-  list-style-type: none;
-  padding: 5px 0;
+:local {
+  .description {
+    cursor: pointer;
+    margin-left: auto;
+    margin-right: 5px;
+    visibility: hidden;
+  }
 
-  &:hover {
-    .kaiju-DraggableItem-description {
-      visibility: visible;
+  .icon {
+    margin-right: 5px;
+  }
+
+  .item {
+    color: #bbb;
+    cursor: grab;
+    display: flex;
+    flex: 0 0 auto;
+    list-style-type: none;
+    padding: 5px 0;
+
+    &:hover {
+      background-color: var(--kaiju-theme-hover-active, #282828);
+
+      .description {
+        visibility: visible;
+      }
     }
   }
-}
-
-.kaiju-DraggableItem:hover::before {
-  background-color: var(--kaiju-theme-hover-active, #282828);
-  content: '';
-  height: 24px;
-  left: 0;
-  margin-top: -3px;
-  position: absolute;
-  right: 0;
-}
-
-.kaiju-DraggableItem-text {
-  position: relative;
-}
-
-.kaiju-DraggableItem-description {
-  cursor: pointer;
-  margin-left: auto;
-  margin-right: 5px;
-  position: relative;
-  visibility: hidden;
 }

--- a/rails/client/app/bundles/kaiju/components/Project/components/Form/ComponentSelect/ComponentSelect.jsx
+++ b/rails/client/app/bundles/kaiju/components/Project/components/Form/ComponentSelect/ComponentSelect.jsx
@@ -1,26 +1,35 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames/bind';
+import iconMap from 'terra-kaiju-plugin/iconMap';
 import { TreeSelect } from 'antd';
 import { refresh } from '../../../utilities/messenger';
 import axios from '../../../../../utilities/axios';
-import './ComponentSelect.scss';
+import styles from './ComponentSelect.scss';
+
+const cx = classNames.bind(styles);
+const TreeNode = TreeSelect.TreeNode;
 
 const propTypes = {
   /**
-   * The availe reference components
+   * The available reference components.
    */
   components: PropTypes.array,
   /**
-   * The component identifier
+   * The component identifier.
    */
   id: PropTypes.string,
   /**
-   * The component property url
+   * The component property url.
    */
   url: PropTypes.string,
 };
 
 const ComponentSelect = ({ components, id, url }) => {
+  /**
+   * Replaces the current component with the selected value.
+   * @param {string} value - The selected option value.
+   */
   const onChange = (value) => {
     axios
       .put(url, { value: { type: value } })
@@ -29,27 +38,47 @@ const ComponentSelect = ({ components, id, url }) => {
       });
   };
 
-  const generateTreeView = (group) => {
-    const children = group.children.map((item) => {
-      if (item.children) {
-        return generateTreeView(item);
-      }
-      const { display, library, name } = item;
-      return <TreeSelect.TreeNode key={`${library}::${name}`} title={display || name} value={`${library}::${name}`} />;
-    });
-    return <TreeSelect.TreeNode key={group.display} title={group.display} disabled>{children}</TreeSelect.TreeNode>;
+  /**
+   * Filters the available select options.
+   * @param {string} input - The search input.
+   * @param {node} option - React Select.Option.
+   */
+  const filterNodes = (input, option) => {
+    const value = option.props.value;
+    return value && value.toLowerCase().includes(input.toLowerCase());
   };
+
+  /**
+   * Generates a TreeSelect from the available reference components.
+   * @param {array} data - Tree data.
+   */
+  const generateTreeView = (data) => {
+    const nodes = data.children.map((child) => {
+      const { children, display, library, name } = child;
+      if (children) {
+        return generateTreeView(child);
+      }
+
+      const value = `${library}::${name}`;
+      const Icon = iconMap[value];
+      const label = display || name;
+      const title = <div className={cx('title')}>{Icon && <Icon className={cx('icon')} />}{label}</div>;
+      return <TreeNode key={value} value={value} title={title} />;
+    });
+
+    return <TreeNode key={data.display} title={data.display} selectable={false}>{nodes}</TreeNode>;
+  };
+
 
   return (
     <TreeSelect
-      className="kaiju-ComponentSelect"
-      showSearch
+      className={cx('select')}
+      dropdownStyle={{ maxHeight: 300 }}
+      filterTreeNode={filterNodes}
       placeholder="Select component"
-      allowClear
-      dropdownStyle={{ maxHeight: 300, overflow: 'auto' }}
       onChange={onChange}
+      showSearch
       treeDefaultExpandAll
-      filterTreeNode={(input, option) => option.props.title.toLowerCase().includes(input.toLowerCase())}
     >
       {components.map(component => generateTreeView(component))}
     </TreeSelect>

--- a/rails/client/app/bundles/kaiju/components/Project/components/Form/ComponentSelect/ComponentSelect.scss
+++ b/rails/client/app/bundles/kaiju/components/Project/components/Form/ComponentSelect/ComponentSelect.scss
@@ -1,13 +1,15 @@
-.kaiju-ComponentSelect {
-  width: 100%;
-}
+:local {
+  .icon {
+    margin-right: 5px;
+  }
 
-// Custom ant styles
-// stylelint-disable
-.ant-select-selection__placeholder {
-  color: #bbb;
-}
+  .select {
+    width: 100%;
+  }
 
-.ant-select-tree-switcher {
-  display: none !important;
+  .title {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
 }

--- a/rails/client/package-lock.json
+++ b/rails/client/package-lock.json
@@ -12151,9 +12151,7 @@
       }
     },
     "terra-kaiju-plugin": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/terra-kaiju-plugin/-/terra-kaiju-plugin-0.5.0.tgz",
-      "integrity": "sha512-3aSOAjA7hxlcgJu44AISsT1v/wqHOVDZUYmBQZ+b8wDjXLXe+ZpeD9+GEGCsAj/XHBFe8OzTqn5BoEYrIzxZcw==",
+      "version": "git+https://github.com/cerner/terra-kaiju-plugin.git#71b321046bfe0e572bd764f9f97d7516b96148f6",
       "requires": {
         "app-root-path": "2.0.1",
         "autoprefixer": "6.7.7",

--- a/rails/client/package.json
+++ b/rails/client/package.json
@@ -36,7 +36,7 @@
     "terra-base": "^2.0.0",
     "terra-i18n": "^1.0.0",
     "terra-icon": "^1.0.0",
-    "terra-kaiju-plugin": "0.5.0",
+    "terra-kaiju-plugin": "git+https://github.com/cerner/terra-kaiju-plugin.git#iconMap",
     "tether": "^1.4.0",
     "uniqid": "^4.1.1"
   },


### PR DESCRIPTION
### Summary
Added a preview for each Icon component in the Component Search and within the editor Component Search.

### Additional Details
Most of these changes are cleaning up the files and uplifting to use CSS Modules.

The terra-kaiju-plugin exports an iconMap. This enables importing the bare minimum icon assets into Kaiju and mapping each icon component type so the previews can be shown.

```
import iconMap from 'terra-kaiju-plugin/iconMap'; // Import the Map

const Icon = iconMap[value];                      // See if the current component type maps to a Component

Icon && <Icon className={cx('icon')} />           // Display the Icon if a matching component is found
```

Thanks for contributing to Kaiju.
@cerner/kaiju

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
