### PR TITLE
Added - Icon previews

### DIFF
--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -12006,7 +12006,7 @@
       }
     },
     "terra-kaiju-plugin": {
-      "version": "git+https://github.com/cerner/terra-kaiju-plugin.git#f194189cc2507b85f8d035571afe721bcf22f8c3",
+      "version": "git+https://github.com/cerner/terra-kaiju-plugin.git#2e4f5d5928db865f65e1939d3b336dd2c6479527",
       "requires": {
         "app-root-path": "2.0.1",
         "autoprefixer": "6.7.7",

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -12006,7 +12006,9 @@
       }
     },
     "terra-kaiju-plugin": {
-      "version": "git+https://github.com/cerner/terra-kaiju-plugin.git#a8f35a954688ba34723e6dd500e23c4d7af0d53d",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/terra-kaiju-plugin/-/terra-kaiju-plugin-0.6.0.tgz",
+      "integrity": "sha512-auUMbjnVpdXMA7BVbezqwk5k8OOcIEPYtiyAu7xTeh5hGo3E7QcvjP6Aag4N1hZQF67eR3ROIIT2pgk2x50QdA==",
       "requires": {
         "app-root-path": "2.0.1",
         "autoprefixer": "6.7.7",

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -12006,7 +12006,7 @@
       }
     },
     "terra-kaiju-plugin": {
-      "version": "git+https://github.com/cerner/terra-kaiju-plugin.git#2e4f5d5928db865f65e1939d3b336dd2c6479527",
+      "version": "git+https://github.com/cerner/terra-kaiju-plugin.git#c247c6da26cd00ee9ff2dcf1255383f55c6ba9e5",
       "requires": {
         "app-root-path": "2.0.1",
         "autoprefixer": "6.7.7",

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -12006,7 +12006,7 @@
       }
     },
     "terra-kaiju-plugin": {
-      "version": "git+https://github.com/cerner/terra-kaiju-plugin.git#c247c6da26cd00ee9ff2dcf1255383f55c6ba9e5",
+      "version": "git+https://github.com/cerner/terra-kaiju-plugin.git#a8f35a954688ba34723e6dd500e23c4d7af0d53d",
       "requires": {
         "app-root-path": "2.0.1",
         "autoprefixer": "6.7.7",
@@ -12059,6 +12059,7 @@
         "terra-icon": "1.17.0",
         "terra-image": "1.15.0",
         "terra-list": "1.19.0",
+        "terra-overlay": "1.17.0",
         "terra-popup": "1.19.0",
         "terra-progress-bar": "1.15.0",
         "terra-responsive-element": "1.15.0",
@@ -12108,6 +12109,52 @@
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/terra-mixins/-/terra-mixins-1.13.0.tgz",
       "integrity": "sha512-yAmp0ka2+pVzlqqnMSQqyfublVG0z2VgVyzC+77SZKcqs41UBdN95kxFfYS/lA1YIfIz+qjjZtUahSBLg6NnLQ=="
+    },
+    "terra-overlay": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/terra-overlay/-/terra-overlay-1.17.0.tgz",
+      "integrity": "sha512-xPxmsGYMh9hsJ/d/yWc1Q3ICxjf+RmWOfnE09lk5hhQtBCh+oMRC8WHaH0Ncg2u7Bc6V0u3IN4QUyKcT8moehw==",
+      "requires": {
+        "classnames": "2.2.5",
+        "focus-trap-react": "3.1.1",
+        "prop-types": "15.6.0",
+        "terra-base": "2.11.1",
+        "terra-icon": "1.18.0"
+      },
+      "dependencies": {
+        "terra-base": {
+          "version": "2.11.1",
+          "resolved": "https://registry.npmjs.org/terra-base/-/terra-base-2.11.1.tgz",
+          "integrity": "sha512-+jWDub683AgMnX1Tu7zRjD7lgIopqpw0NIG1RlgBVNwSwYOjK9N1r3CBGZvBAaKBZF3rxiDSPhEex/8KCcNG8Q==",
+          "requires": {
+            "classnames": "2.2.5",
+            "prop-types": "15.6.0",
+            "terra-i18n": "1.14.0",
+            "terra-mixins": "1.13.0"
+          }
+        },
+        "terra-i18n": {
+          "version": "1.14.0",
+          "resolved": "https://registry.npmjs.org/terra-i18n/-/terra-i18n-1.14.0.tgz",
+          "integrity": "sha512-WDdbFa5x6jA+Hhxco8qWqsG1mOY/w9IQN9n31kCDZRncHaNMGf+BUHpKPJvCotrllgkIHKNMuDY3t4Ze7IqVig==",
+          "requires": {
+            "classnames": "2.2.5",
+            "intl": "1.2.5",
+            "prop-types": "15.6.0",
+            "react-intl": "2.4.0"
+          }
+        },
+        "terra-icon": {
+          "version": "1.18.0",
+          "resolved": "https://registry.npmjs.org/terra-icon/-/terra-icon-1.18.0.tgz",
+          "integrity": "sha512-s7O38X91D8LbSHSFv8ucuHFZIqkSQ4HymA/CQldYI5xvV2+n5EVMoOTtb3K+PBu8Fl1Y/h3hnwGd3NAVJnuf7w==",
+          "requires": {
+            "classnames": "2.2.5",
+            "prop-types": "15.6.0",
+            "terra-base": "2.11.1"
+          }
+        }
+      }
     },
     "terra-popup": {
       "version": "1.19.0",

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -12006,9 +12006,7 @@
       }
     },
     "terra-kaiju-plugin": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/terra-kaiju-plugin/-/terra-kaiju-plugin-0.5.0.tgz",
-      "integrity": "sha512-3aSOAjA7hxlcgJu44AISsT1v/wqHOVDZUYmBQZ+b8wDjXLXe+ZpeD9+GEGCsAj/XHBFe8OzTqn5BoEYrIzxZcw==",
+      "version": "git+https://github.com/cerner/terra-kaiju-plugin.git#f194189cc2507b85f8d035571afe721bcf22f8c3",
       "requires": {
         "app-root-path": "2.0.1",
         "autoprefixer": "6.7.7",

--- a/node/package.json
+++ b/node/package.json
@@ -38,7 +38,7 @@
     "react-dom": "^15.6.2",
     "request": "^2.83.0",
     "request-promise": "^4.2.2",
-    "terra-kaiju-plugin": "0.5.0",
+    "terra-kaiju-plugin": "git+https://github.com/cerner/terra-kaiju-plugin.git#KaijuIconMap",
     "webpack": "^3.6.0"
   },
   "devDependencies": {

--- a/node/package.json
+++ b/node/package.json
@@ -38,7 +38,7 @@
     "react-dom": "^15.6.2",
     "request": "^2.83.0",
     "request-promise": "^4.2.2",
-    "terra-kaiju-plugin": "git+https://github.com/cerner/terra-kaiju-plugin.git#KaijuIconMap",
+    "terra-kaiju-plugin": "0.6.0",
     "webpack": "^3.6.0"
   },
   "devDependencies": {

--- a/rails/changelog.md
+++ b/rails/changelog.md
@@ -2,6 +2,7 @@
 ### Added
 - Ability to resize the component library and layers section
 - Icon previews within the component library and search
+- Terra Overlay
 
 ### Fixed
 - Workspaces can be resized to any breakpoint regardless of screen size

--- a/rails/changelog.md
+++ b/rails/changelog.md
@@ -1,6 +1,7 @@
-## February 7th, 2018
+## February 9th, 2018
 ### Added
 - Ability to resize the component library and layers section
+- Icon previews within the component library and search
 
 ### Fixed
 - Workspaces can be resized to any breakpoint regardless of screen size

--- a/rails/client/app/bundles/kaiju/components/Component/components/Element/Element.jsx
+++ b/rails/client/app/bundles/kaiju/components/Component/components/Element/Element.jsx
@@ -37,6 +37,12 @@ class Element extends React.Component {
   register() {
     // eslint-disable-next-line react/no-find-dom-node
     const node = ReactDOM.findDOMNode(this);
+
+    // Some components are conditionally rendered into the dom.
+    if (!node) {
+      return;
+    }
+
     const { kaijuId, kaijuType, kaijuSortable } = this.props;
 
     node.setAttribute('data-kaiju-component-id', kaijuId);

--- a/rails/client/app/bundles/kaiju/components/Project/components/DraggableItem/DraggableItem.jsx
+++ b/rails/client/app/bundles/kaiju/components/Project/components/DraggableItem/DraggableItem.jsx
@@ -1,24 +1,28 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames/bind';
+import iconMap from 'terra-kaiju-plugin/iconMap';
 import { Icon, Tooltip } from 'antd';
 import { select } from '../../utilities/messenger';
-import './DraggableItem.scss';
+import styles from './DraggableItem.scss';
+
+const cx = classNames.bind(styles);
 
 const propTypes = {
   /**
-   * Description text
+   * Description text.
    */
   description: PropTypes.string,
   /**
-   * Display text
+   * Display text.
    */
   display: PropTypes.string,
   /**
-   * The component library
+   * The component library.
    */
   library: PropTypes.string,
   /**
-   * The component name
+   * The component name.
    */
   name: PropTypes.string,
 };
@@ -32,12 +36,14 @@ const DraggableItem = ({ display, description, library, name }) => {
     event.dataTransfer.setData('text', JSON.stringify({ type: `${library}::${name}` }));
   }
 
+  const IconType = iconMap[name];
+
   return (
-    <li className="kaiju-DraggableItem" draggable onDragStart={handleDragStart}>
-      <span className="kaiju-DraggableItem-text">
-        {display}
+    <li className={cx('item')} draggable onDragStart={handleDragStart}>
+      <span className={cx('display')}>
+        {IconType && <IconType className={cx('icon')} />}{display}
       </span>
-      <span className="kaiju-DraggableItem-description">
+      <span className={cx('description')}>
         <Tooltip placement="right" title={description}>
           <Icon type="question-circle-o" />
         </Tooltip>

--- a/rails/client/app/bundles/kaiju/components/Project/components/DraggableItem/DraggableItem.scss
+++ b/rails/client/app/bundles/kaiju/components/Project/components/DraggableItem/DraggableItem.scss
@@ -1,36 +1,29 @@
-.kaiju-DraggableItem {
-  color: #bbb;
-  cursor: grab;
-  display: flex;
-  flex: 0 0 auto;
-  list-style-type: none;
-  padding: 5px 0;
+:local {
+  .description {
+    cursor: pointer;
+    margin-left: auto;
+    margin-right: 5px;
+    visibility: hidden;
+  }
 
-  &:hover {
-    .kaiju-DraggableItem-description {
-      visibility: visible;
+  .icon {
+    margin-right: 5px;
+  }
+
+  .item {
+    color: #bbb;
+    cursor: grab;
+    display: flex;
+    flex: 0 0 auto;
+    list-style-type: none;
+    padding: 5px 0;
+
+    &:hover {
+      background-color: var(--kaiju-theme-hover-active, #282828);
+
+      .description {
+        visibility: visible;
+      }
     }
   }
-}
-
-.kaiju-DraggableItem:hover::before {
-  background-color: var(--kaiju-theme-hover-active, #282828);
-  content: '';
-  height: 24px;
-  left: 0;
-  margin-top: -3px;
-  position: absolute;
-  right: 0;
-}
-
-.kaiju-DraggableItem-text {
-  position: relative;
-}
-
-.kaiju-DraggableItem-description {
-  cursor: pointer;
-  margin-left: auto;
-  margin-right: 5px;
-  position: relative;
-  visibility: hidden;
 }

--- a/rails/client/app/bundles/kaiju/components/Project/components/Editor/Editor.scss
+++ b/rails/client/app/bundles/kaiju/components/Project/components/Editor/Editor.scss
@@ -8,6 +8,7 @@
 
 .kaiju-Editor-form {
   flex: auto;
+  margin-top: 5px;
   min-height: 0;
   overflow: auto;
 }

--- a/rails/client/app/bundles/kaiju/components/Project/components/Form/ComponentSelect/ComponentSelect.scss
+++ b/rails/client/app/bundles/kaiju/components/Project/components/Form/ComponentSelect/ComponentSelect.scss
@@ -1,13 +1,15 @@
-.kaiju-ComponentSelect {
-  width: 100%;
-}
+:local {
+  .icon {
+    margin-right: 5px;
+  }
 
-// Custom ant styles
-// stylelint-disable
-.ant-select-selection__placeholder {
-  color: #bbb;
-}
+  .select {
+    width: 100%;
+  }
 
-.ant-select-tree-switcher {
-  display: none !important;
+  .title {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
 }

--- a/rails/client/package-lock.json
+++ b/rails/client/package-lock.json
@@ -12151,7 +12151,9 @@
       }
     },
     "terra-kaiju-plugin": {
-      "version": "git+https://github.com/cerner/terra-kaiju-plugin.git#a8f35a954688ba34723e6dd500e23c4d7af0d53d",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/terra-kaiju-plugin/-/terra-kaiju-plugin-0.6.0.tgz",
+      "integrity": "sha512-auUMbjnVpdXMA7BVbezqwk5k8OOcIEPYtiyAu7xTeh5hGo3E7QcvjP6Aag4N1hZQF67eR3ROIIT2pgk2x50QdA==",
       "requires": {
         "app-root-path": "2.0.1",
         "autoprefixer": "6.7.7",

--- a/rails/client/package-lock.json
+++ b/rails/client/package-lock.json
@@ -12151,7 +12151,7 @@
       }
     },
     "terra-kaiju-plugin": {
-      "version": "git+https://github.com/cerner/terra-kaiju-plugin.git#f194189cc2507b85f8d035571afe721bcf22f8c3",
+      "version": "git+https://github.com/cerner/terra-kaiju-plugin.git#2e4f5d5928db865f65e1939d3b336dd2c6479527",
       "requires": {
         "app-root-path": "2.0.1",
         "autoprefixer": "6.7.7",

--- a/rails/client/package-lock.json
+++ b/rails/client/package-lock.json
@@ -12151,7 +12151,7 @@
       }
     },
     "terra-kaiju-plugin": {
-      "version": "git+https://github.com/cerner/terra-kaiju-plugin.git#2e4f5d5928db865f65e1939d3b336dd2c6479527",
+      "version": "git+https://github.com/cerner/terra-kaiju-plugin.git#c247c6da26cd00ee9ff2dcf1255383f55c6ba9e5",
       "requires": {
         "app-root-path": "2.0.1",
         "autoprefixer": "6.7.7",

--- a/rails/client/package-lock.json
+++ b/rails/client/package-lock.json
@@ -12151,9 +12151,7 @@
       }
     },
     "terra-kaiju-plugin": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/terra-kaiju-plugin/-/terra-kaiju-plugin-0.5.0.tgz",
-      "integrity": "sha512-3aSOAjA7hxlcgJu44AISsT1v/wqHOVDZUYmBQZ+b8wDjXLXe+ZpeD9+GEGCsAj/XHBFe8OzTqn5BoEYrIzxZcw==",
+      "version": "git+https://github.com/cerner/terra-kaiju-plugin.git#f194189cc2507b85f8d035571afe721bcf22f8c3",
       "requires": {
         "app-root-path": "2.0.1",
         "autoprefixer": "6.7.7",

--- a/rails/client/package-lock.json
+++ b/rails/client/package-lock.json
@@ -12151,7 +12151,7 @@
       }
     },
     "terra-kaiju-plugin": {
-      "version": "git+https://github.com/cerner/terra-kaiju-plugin.git#c247c6da26cd00ee9ff2dcf1255383f55c6ba9e5",
+      "version": "git+https://github.com/cerner/terra-kaiju-plugin.git#a8f35a954688ba34723e6dd500e23c4d7af0d53d",
       "requires": {
         "app-root-path": "2.0.1",
         "autoprefixer": "6.7.7",
@@ -12204,6 +12204,7 @@
         "terra-icon": "1.17.0",
         "terra-image": "1.15.0",
         "terra-list": "1.19.0",
+        "terra-overlay": "1.17.0",
         "terra-popup": "1.19.0",
         "terra-progress-bar": "1.15.0",
         "terra-responsive-element": "1.15.0",
@@ -12300,6 +12301,52 @@
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/terra-mixins/-/terra-mixins-1.13.0.tgz",
       "integrity": "sha512-yAmp0ka2+pVzlqqnMSQqyfublVG0z2VgVyzC+77SZKcqs41UBdN95kxFfYS/lA1YIfIz+qjjZtUahSBLg6NnLQ=="
+    },
+    "terra-overlay": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/terra-overlay/-/terra-overlay-1.17.0.tgz",
+      "integrity": "sha512-xPxmsGYMh9hsJ/d/yWc1Q3ICxjf+RmWOfnE09lk5hhQtBCh+oMRC8WHaH0Ncg2u7Bc6V0u3IN4QUyKcT8moehw==",
+      "requires": {
+        "classnames": "2.2.5",
+        "focus-trap-react": "3.1.1",
+        "prop-types": "15.6.0",
+        "terra-base": "2.11.1",
+        "terra-icon": "1.18.0"
+      },
+      "dependencies": {
+        "terra-base": {
+          "version": "2.11.1",
+          "resolved": "https://registry.npmjs.org/terra-base/-/terra-base-2.11.1.tgz",
+          "integrity": "sha512-+jWDub683AgMnX1Tu7zRjD7lgIopqpw0NIG1RlgBVNwSwYOjK9N1r3CBGZvBAaKBZF3rxiDSPhEex/8KCcNG8Q==",
+          "requires": {
+            "classnames": "2.2.5",
+            "prop-types": "15.6.0",
+            "terra-i18n": "1.14.0",
+            "terra-mixins": "1.13.0"
+          }
+        },
+        "terra-i18n": {
+          "version": "1.14.0",
+          "resolved": "https://registry.npmjs.org/terra-i18n/-/terra-i18n-1.14.0.tgz",
+          "integrity": "sha512-WDdbFa5x6jA+Hhxco8qWqsG1mOY/w9IQN9n31kCDZRncHaNMGf+BUHpKPJvCotrllgkIHKNMuDY3t4Ze7IqVig==",
+          "requires": {
+            "classnames": "2.2.5",
+            "intl": "1.2.5",
+            "prop-types": "15.6.0",
+            "react-intl": "2.4.0"
+          }
+        },
+        "terra-icon": {
+          "version": "1.18.0",
+          "resolved": "https://registry.npmjs.org/terra-icon/-/terra-icon-1.18.0.tgz",
+          "integrity": "sha512-s7O38X91D8LbSHSFv8ucuHFZIqkSQ4HymA/CQldYI5xvV2+n5EVMoOTtb3K+PBu8Fl1Y/h3hnwGd3NAVJnuf7w==",
+          "requires": {
+            "classnames": "2.2.5",
+            "prop-types": "15.6.0",
+            "terra-base": "2.11.1"
+          }
+        }
+      }
     },
     "terra-popup": {
       "version": "1.19.0",

--- a/rails/client/package.json
+++ b/rails/client/package.json
@@ -36,7 +36,7 @@
     "terra-base": "^2.0.0",
     "terra-i18n": "^1.0.0",
     "terra-icon": "^1.0.0",
-    "terra-kaiju-plugin": "git+https://github.com/cerner/terra-kaiju-plugin.git#KaijuIconMap",
+    "terra-kaiju-plugin": "0.6.0",
     "tether": "^1.4.0",
     "uniqid": "^4.1.1"
   },

--- a/rails/client/package.json
+++ b/rails/client/package.json
@@ -36,7 +36,7 @@
     "terra-base": "^2.0.0",
     "terra-i18n": "^1.0.0",
     "terra-icon": "^1.0.0",
-    "terra-kaiju-plugin": "0.5.0",
+    "terra-kaiju-plugin": "git+https://github.com/cerner/terra-kaiju-plugin.git#KaijuIconMap",
     "tether": "^1.4.0",
     "uniqid": "^4.1.1"
   },


### PR DESCRIPTION
### Summary
- Added a preview for each Icon component in the Component Search and within the editor Component Search.
- Uplifted DraggableItem and ComponentSearch to use CSS Modules

An example of the IconMap can be found here: https://github.com/cerner/terra-kaiju-plugin/pull/12

Resolves #8.

![image](https://user-images.githubusercontent.com/6720991/36039608-92e8bde2-0d88-11e8-8211-e0c1044f8717.png)

![image](https://user-images.githubusercontent.com/6720991/36039629-a951b868-0d88-11e8-85a1-455bf4dc035b.png)

Thanks for contributing to Kaiju.
@cerner/kaiju

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
