### PR TITLE
Added - ExtractTextPlugin to load stylesheets in parallel to javascript assets

### DIFF
--- a/rails/app/views/layouts/application.html.erb
+++ b/rails/app/views/layouts/application.html.erb
@@ -2,9 +2,9 @@
 <html>
 <head>
   <title>Kaiju</title>
-  <%= javascript_pack_tag 'project' %>
-  <%= yield :javascripts %>
   <%= csrf_meta_tags %>
+  <%= stylesheet_pack_tag 'project' %>
+  <%= javascript_pack_tag 'project' %>
 </head>
 <body>
 

--- a/rails/app/views/layouts/code.html.erb
+++ b/rails/app/views/layouts/code.html.erb
@@ -2,8 +2,9 @@
 <html>
 <head>
   <title>Kaiju</title>
-  <%= javascript_pack_tag 'code' %>
   <%= csrf_meta_tags %>
+  <%= stylesheet_pack_tag 'code' %>
+  <%= javascript_pack_tag 'code' %>
 </head>
 <body>
 

--- a/rails/app/views/layouts/components.html.erb
+++ b/rails/app/views/layouts/components.html.erb
@@ -2,8 +2,9 @@
 <html dir="ltr">
 <head>
   <title>Kaiju</title>
-  <%= javascript_pack_tag 'component' %>
   <%= csrf_meta_tags %>
+  <%= stylesheet_pack_tag 'component' %>
+  <%= javascript_pack_tag 'component' %>
 </head>
 <body>
 

--- a/rails/app/views/layouts/guide.html.erb
+++ b/rails/app/views/layouts/guide.html.erb
@@ -2,8 +2,9 @@
 <html>
 <head>
   <title>Kaiju</title>
-  <%= javascript_pack_tag 'guide' %>
   <%= csrf_meta_tags %>
+  <%= stylesheet_pack_tag 'guide' %>
+  <%= javascript_pack_tag 'guide' %>
 </head>
 <body>
 

--- a/rails/app/views/layouts/health.html.erb
+++ b/rails/app/views/layouts/health.html.erb
@@ -2,7 +2,6 @@
 <html>
 <head>
   <title>Kaiju</title>
-  <%= javascript_pack_tag 'code' %>
   <%= csrf_meta_tags %>
 </head>
 <body>

--- a/rails/app/views/layouts/launch.html.erb
+++ b/rails/app/views/layouts/launch.html.erb
@@ -2,8 +2,9 @@
 <html>
 <head>
   <title>Kaiju</title>
-  <%= javascript_pack_tag 'launch' %>
   <%= csrf_meta_tags %>
+  <%= stylesheet_pack_tag 'launch' %>
+  <%= javascript_pack_tag 'launch' %>
 </head>
 <body>
 

--- a/rails/app/views/layouts/preview.html.erb
+++ b/rails/app/views/layouts/preview.html.erb
@@ -2,8 +2,9 @@
 <html dir="ltr">
 <head>
   <title>Kaiju</title>
-  <%= javascript_pack_tag 'preview' %>
   <%= csrf_meta_tags %>
+  <%= stylesheet_pack_tag 'preview' %>
+  <%= javascript_pack_tag 'preview' %>
 </head>
 <body>
 

--- a/rails/client/package-lock.json
+++ b/rails/client/package-lock.json
@@ -3372,6 +3372,18 @@
         "is-extglob": "1.0.0"
       }
     },
+    "extract-text-webpack-plugin": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extract-text-webpack-plugin/-/extract-text-webpack-plugin-3.0.2.tgz",
+      "integrity": "sha512-bt/LZ4m5Rqt/Crl2HiKuAl/oqg0psx1tsTLkvWbJen1CtD+fftkZhMaQ9HOtY2gWsl2Wq+sABmMVi9z3DhKWQQ==",
+      "dev": true,
+      "requires": {
+        "async": "2.6.0",
+        "loader-utils": "1.1.0",
+        "schema-utils": "0.3.0",
+        "webpack-sources": "1.1.0"
+      }
+    },
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",

--- a/rails/client/package.json
+++ b/rails/client/package.json
@@ -60,6 +60,7 @@
     "eslint-plugin-jsx-a11y": "^5.0.0",
     "eslint-plugin-react": "^7.0.0",
     "expose-loader": "^0.7.3",
+    "extract-text-webpack-plugin": "^3.0.2",
     "glob": "^7.1.2",
     "imports-loader": "^0.7.1",
     "jest": "^22.1.4",

--- a/rails/client/webpack.config.js
+++ b/rails/client/webpack.config.js
@@ -1,7 +1,3 @@
-// For inspiration on your webpack configuration, see:
-// https://github.com/shakacode/react_on_rails/tree/master/spec/dummy/client
-// https://github.com/shakacode/react-webpack-rails-tutorial/tree/master/client
-
 const webpack = require('webpack');
 const path = require('path');
 
@@ -12,6 +8,7 @@ const i18nSupportedLocales = require('terra-i18n/lib/i18nSupportedLocales');
 
 const Autoprefixer = require('autoprefixer');
 const CustomProperties = require('postcss-custom-properties');
+const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const GatherDependencies = require('./plugins/gather-dependencies');
 const ManifestPlugin = require('webpack-manifest-plugin');
 const webpackConfigLoader = require('react-on-rails/webpackConfigLoader');
@@ -59,17 +56,15 @@ const config = {
         NODE_ENV: JSON.stringify(process.env.NODE_ENV),
       },
     }),
-    // new webpack.EnvironmentPlugin({
-    //   NODE_ENV: 'development', // use 'development' unless process.env.NODE_ENV is defined
-    //   DEBUG: false,
-    // }),
     new ManifestPlugin({ publicPath: output.publicPath, writeToFileEmit: true }),
     new I18nAggregatorPlugin({
       baseDirectory: __dirname,
       supportedLocales: i18nSupportedLocales,
     }),
     new webpack.NamedChunksPlugin(),
-    // new webpack.optimize.UglifyJsPlugin({ sourceMap: true, minimize: true }),
+    new ExtractTextPlugin({
+      filename: '[name]-[hash].css',
+    }),
   ],
 
   module: {
@@ -91,41 +86,41 @@ const config = {
       },
       {
         test: /\.(scss|css)$/,
-        use: [
-          {
-            loader: 'style-loader',
-          },
-          {
-            loader: 'css-loader',
-            options: {
-              sourceMap: true,
-              importLoaders: 2,
-              localIdentName: '[name]_[local]_[hash:base64:5]',
-            },
-          },
-          {
-            loader: 'postcss-loader',
-            options: {
-              plugins() {
-                return [
-                  Autoprefixer({
-                    browsers: [
-                      'ie >= 10',
-                      'last 2 versions',
-                      'last 2 android versions',
-                      'last 2 and_chr versions',
-                      'iOS >= 8',
-                    ],
-                  }),
-                  CustomProperties(),
-                ];
+        use: ExtractTextPlugin.extract({
+          fallback: 'style-loader',
+          use: [
+            {
+              loader: 'css-loader',
+              options: {
+                sourceMap: true,
+                importLoaders: 2,
+                localIdentName: '[name]_[local]_[hash:base64:5]',
               },
             },
-          },
-          {
-            loader: 'sass-loader',
-          },
-        ],
+            {
+              loader: 'postcss-loader',
+              options: {
+                plugins() {
+                  return [
+                    Autoprefixer({
+                      browsers: [
+                        'ie >= 10',
+                        'last 2 versions',
+                        'last 2 android versions',
+                        'last 2 and_chr versions',
+                        'iOS >= 8',
+                      ],
+                    }),
+                    CustomProperties(),
+                  ];
+                },
+              },
+            },
+            {
+              loader: 'sass-loader',
+            },
+          ],
+        }),
       },
     ],
   },


### PR DESCRIPTION
### Summary
Extracting the style sheets and loading them in parallel increases initial page load performance.

https://github.com/webpack-contrib/extract-text-webpack-plugin

Resolves #98.

Thanks for contributing to Kaiju.
@cerner/kaiju

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
