### PR TITLE
Added - A Read-Only link within the share menu

### DIFF
--- a/rails/changelog.md
+++ b/rails/changelog.md
@@ -2,7 +2,7 @@
 ### Updated
 - Upgraded to React 16 Terra components
 - Upgraded Buttons to version 2. Pre-existing Buttons will need modification
-- Redesigned the share UI to provide a read-only sharing option
+- Share dialog includes edit and read-only invitation links
 
 ## February 9th, 2018
 ### Added

--- a/rails/changelog.md
+++ b/rails/changelog.md
@@ -1,7 +1,10 @@
-## February 19th, 2018
+## February 25th, 2018
 ### Updated
 - Upgraded to React 16 Terra components
 - Upgraded Buttons to version 2. Pre-existing Buttons will need modification
+
+### Added
+- Read-Only link within share menu
 
 ## February 9th, 2018
 ### Added

--- a/rails/changelog.md
+++ b/rails/changelog.md
@@ -4,7 +4,7 @@
 - Upgraded Buttons to version 2. Pre-existing Buttons will need modification
 
 ### Added
-- Read-Only link within share menu
+- Read-Only link within the share menu
 
 ## February 9th, 2018
 ### Added

--- a/rails/changelog.md
+++ b/rails/changelog.md
@@ -2,9 +2,7 @@
 ### Updated
 - Upgraded to React 16 Terra components
 - Upgraded Buttons to version 2. Pre-existing Buttons will need modification
-
-### Added
-- Read-Only link within the share menu
+- Redesigned the share UI to provide a read-only sharing option
 
 ## February 9th, 2018
 ### Added

--- a/rails/client/app/bundles/kaiju/components/Project/Project.scss
+++ b/rails/client/app/bundles/kaiju/components/Project/Project.scss
@@ -47,6 +47,12 @@
   background-color: var(--kaiju-theme-background-color, #222);
 }
 
+// Globally updates the selection highlighting color.
+// TODO: Move this into a base theme file.
+*::selection {
+  background: var(--kaiju-theme-color, #1db954);
+}
+
 *::-webkit-scrollbar {
   border-radius: 10px;
   box-shadow: inset 0 0 6px rgba(0,0,0,.3);

--- a/rails/client/app/bundles/kaiju/components/Project/components/ActionBar/ActionBar.jsx
+++ b/rails/client/app/bundles/kaiju/components/Project/components/ActionBar/ActionBar.jsx
@@ -3,8 +3,9 @@ import PropTypes from 'prop-types';
 import Mousetrap from 'mousetrap';
 import IconUndo from 'terra-icon/lib/icon/IconReply';
 import IconRedo from 'terra-icon/lib/icon/IconForward';
-import axios from '../../../../utilities/axios';
+import { Icon } from 'antd';
 import { copy, duplicate, destroy, paste, refresh, select } from '../../utilities/messenger';
+import axios from '../../../../utilities/axios';
 import ActionItem from './ActionItem/ActionItem';
 import Delete from './Delete/Delete';
 import Duplicate from '../../containers/DuplicateWorkspaceContainer';
@@ -158,7 +159,9 @@ class ActionBar extends React.Component {
           <ActionItem iconType="code-o" onClick={navigateToCode} title="Code" />
           <ActionItem iconType="bars" onClick={navigateToAttributes} title="Attributes" />
           <ActionItem title="Share">
-            <Share collaborationInvitation={collaborationInvitation} />
+            <Share collaborationInvitation={collaborationInvitation} readOnlyUrl={workspace.url} type="WORKSPACE">
+              <Icon type="share-alt" />
+            </Share>
           </ActionItem>
           <ActionItem iconType="eye-o" onClick={navigateToPreview} title="Preview" />
           <SizeControl onChange={onResize} selectedSize={canvasSize} />

--- a/rails/client/app/bundles/kaiju/components/Project/components/ActionBar/Share/Share.jsx
+++ b/rails/client/app/bundles/kaiju/components/Project/components/ActionBar/Share/Share.jsx
@@ -1,57 +1,157 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Icon, Input, Modal, Tooltip } from 'antd';
+import classNames from 'classnames/bind';
 import CopyToClipboard from 'react-copy-to-clipboard';
-import { Modal, Icon, Input, Tooltip } from 'antd';
-import classNames from 'classnames';
+import Magician from '../../../../common/Magician/Magician';
 import axios from '../../../../../utilities/axios';
-import './Share.scss';
+import styles from './Share.scss';
 
-const propTypes = {
-  collaborationInvitation: PropTypes.string,
+const cx = classNames.bind(styles);
+
+const ShareType = {
+  PROJECT: 'PROJECT',
+  WORKSPACE: 'WORKSPACE',
 };
 
-class Rename extends React.Component {
+const Permissions = {
+  READ: 'READ',
+  WRITE: 'WRITE',
+};
+
+const Descriptions = {
+  PROJECT: {
+    TITLE: 'Share Project',
+    INFO: 'Share link expires in 24 hours.',
+    READ: 'A public link to view your project but not make any edits.',
+    WRITE: 'Grants permission to make edits to your entire project.',
+  },
+  WORKSPACE: {
+    TITLE: 'Share Workspace',
+    INFO: 'Share link expires in 24 hours.',
+    READ: 'A public link to view your workspace but not make any edits.',
+    WRITE: 'Grants permission to make edits to your workspace.',
+  },
+  READ: {
+    TITLE: 'Read-Only link',
+    ALT: 'Share link',
+  },
+  WRITE: {
+    TITLE: 'Share link',
+    ALT: 'Read-Only link',
+  },
+};
+
+const propTypes = {
+  /**
+   * The click target to open the modal.
+   */
+  children: PropTypes.node,
+  /**
+   * The request route for generating a new invitation.
+   */
+  collaborationInvitation: PropTypes.string,
+  /**
+   * The public read-only URL.
+   */
+  readOnlyUrl: PropTypes.string,
+  /**
+   * The type of content being shared.
+   */
+  type: PropTypes.oneOf([ShareType.PROJECT, ShareType.WORKSPACE]),
+};
+
+class Share extends React.Component {
   constructor(props) {
     super(props);
-    this.state = { isOpen: false };
+    this.state = { isOpen: false, permissions: Permissions.WRITE };
+    this.ref = this.ref.bind(this);
+    this.select = this.select.bind(this);
     this.showModal = this.showModal.bind(this);
     this.handleCancel = this.handleCancel.bind(this);
+    this.togglePermissions = this.togglePermissions.bind(this);
   }
 
+  /**
+   * Handles the cancel action of the share modal.
+   */
   handleCancel() {
     this.setState({ isOpen: false, shareUrl: null });
   }
 
+  /**
+   * Selects the share invitation text.
+   */
+  select() {
+    this.input.refs.input.select();
+  }
+
+  /**
+   * Sets the input ref.
+   */
+  ref(input) {
+    this.input = input;
+  }
+
+  /**
+   * Toggles between a read-only an edit access.
+   */
+  togglePermissions() {
+    const permissions = this.state.permissions === Permissions.WRITE ? Permissions.READ : Permissions.WRITE;
+    this.setState({ permissions });
+
+    // The input can only be selected when the loading animation completes.
+    setTimeout(this.select, 200);
+  }
+
+  /**
+   * Opens the share modal.
+   */
   showModal() {
     axios
       .get(this.props.collaborationInvitation)
       .then(({ data }) => {
-        this.setState({ isOpen: true, shareUrl: data.url, copied: false });
+        this.setState({ isOpen: true, shareUrl: data.url });
+
+        // The input can only be selected when the modal has finished animating.
+        setTimeout(this.select, 200);
       });
   }
 
   render() {
-    const clipboard = (
-      <CopyToClipboard text={this.state.shareUrl} onCopy={() => this.setState({ copied: true })}>
-        <Tooltip placement="bottom" title="Copied!" trigger="click">
-          <Icon type="copy" className={classNames(['kaiju-Share-clipboard', { 'is-copied': this.state.copied }])} />
+    const { isOpen, permissions, shareUrl } = this.state;
+    const { children, readOnlyUrl, type } = this.props;
+
+    const isShareable = permissions === Permissions.WRITE;
+    const value = isShareable ? shareUrl : readOnlyUrl;
+
+    const addon = (
+      <CopyToClipboard text={value}>
+        <Tooltip placement="bottom" title="Copied!" trigger="click" onClick={this.select}>
+          <span className={cx('copy')}>Copy</span>
         </Tooltip>
       </CopyToClipboard>
     );
 
     return (
       <div onClick={this.showModal} role="presentation">
-        <Icon type="share-alt" />
-        <Modal className="kaiju-Share" title="Share" visible={this.state.isOpen} footer={null} onCancel={this.handleCancel}>
-          <div className="kaiju-Share-title">Workspace link:</div>
-          <Input value={this.state.shareUrl} readOnly addonAfter={clipboard} className="kaiju-Share-input" />
-          <div className="kaiju-Share-info">Users will have 24 hours to activate this link and become a collaborator</div>
+        {children}
+        <Modal title={Descriptions[type].TITLE} onCancel={this.handleCancel} visible={isOpen} footer={null}>
+          <Magician key={permissions}>
+            <h2 className={cx('title')}>{Descriptions[permissions].TITLE}</h2>
+            <p className={cx('description')}>{Descriptions[type][permissions]}</p>
+            <Input readOnly value={value} addonAfter={addon} onFocus={this.select} ref={this.ref} />
+            {isShareable && <div className={cx('info')}>{Descriptions[type].INFO}</div>}
+            <div className={cx('toggle', { 'is-edit': isShareable })} onClick={this.togglePermissions} role="presentation">
+              Get a {Descriptions[permissions].ALT} <Icon type={isShareable ? 'eye-o' : 'edit'} />
+            </div>
+          </Magician>
         </Modal>
       </div>
     );
   }
 }
 
-Rename.propTypes = propTypes;
+Share.propTypes = propTypes;
 
-export default Rename;
+export default Share;

--- a/rails/client/app/bundles/kaiju/components/Project/components/ActionBar/Share/Share.scss
+++ b/rails/client/app/bundles/kaiju/components/Project/components/ActionBar/Share/Share.scss
@@ -1,24 +1,45 @@
-.kaiju-Share {
-  // stylelint-disable-next-line
-  .ant-input-group-wrapper {
-    padding: 5px 0;
-    width: 100%;
+:local {
+  .description {
+    color: #999;
+    padding: 10px 0 5px;
   }
-}
 
-.kaiju-Share-clipboard {
-  transition: 0.5s ease-in-out;
+  .copy {
+    color: #f8f8f8;
+    padding: 4px 7px;
+  }
 
-  &.is-copied {
+  .info {
     color: var(--kaiju-theme-color, #1db954);
+    margin-top: 5px;
+  }
+
+  .title {
+    color: #fff;
+  }
+
+  .toggle {
+    color: #999;
+    cursor: pointer;
+    font-size: 14px;
+    margin-top: 10px;
+    text-align: right;
+
+    &.is-edit {
+      margin-top: 0;
+    }
+
+    &:hover {
+      text-decoration: underline;
+    }
   }
 }
 
-.kaiju-Share-info {
-  color: #999;
-  margin-bottom: 5px;
-}
-
-.kaiju-Share-title {
-  color: #bbb;
+// Custom ant style overrides.
+.ant-input-group-addon {
+  background-color: rgba(29, 185, 84, 0.5);
+  border-color: var(--kaiju-theme-color, #1db954);
+  border-left: 1px solid var(--kaiju-theme-color, #1db954) !important;
+  cursor: pointer;
+  padding: 0;
 }

--- a/rails/client/app/bundles/kaiju/components/Project/containers/menu/ShareMenuItem.jsx
+++ b/rails/client/app/bundles/kaiju/components/Project/containers/menu/ShareMenuItem.jsx
@@ -1,61 +1,23 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import CopyToClipboard from 'react-copy-to-clipboard';
-import { Modal, Icon, Input, Tooltip } from 'antd';
 import { connect } from 'react-redux';
-import classNames from 'classnames';
-import MenuItem from '../../components/Menu/MenuItem/MenuItem';
-import axios from '../../../../utilities/axios';
+import classNames from 'classnames/bind';
+import Share from '../../components/ActionBar/Share/Share';
+import styles from './ShareMenuItem.scss';
 
-const propTypes = {
-  collaborationInvitation: PropTypes.string,
-};
+const cx = classNames.bind(styles);
 
-class ShareMenuItem extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = { isOpen: false };
-    this.showModal = this.showModal.bind(this);
-    this.handleCancel = this.handleCancel.bind(this);
-  }
-
-  handleCancel() {
-    this.setState({ isOpen: false, shareUrl: null });
-  }
-
-  showModal() {
-    axios
-      .get(this.props.collaborationInvitation)
-      .then(({ data }) => {
-        this.setState({ isOpen: true, shareUrl: data.url, copied: false });
-      });
-  }
-
-  render() {
-    const clipboard = (
-      <CopyToClipboard text={this.state.shareUrl} onCopy={() => this.setState({ copied: true })}>
-        <Tooltip placement="bottom" title="Copied!" trigger="click">
-          <Icon type="copy" className={classNames(['kaiju-Share-clipboard', { 'is-copied': this.state.copied }])} />
-        </Tooltip>
-      </CopyToClipboard>
-    );
-
-    return (
-      <MenuItem title="Share" onClick={this.showModal}>
-        <Modal className="kaiju-Share" title="Share" visible={this.state.isOpen} footer={null} onCancel={this.handleCancel}>
-          <div className="kaiju-Share-title">Project link:</div>
-          <Input value={this.state.shareUrl} readOnly addonAfter={clipboard} className="kaiju-Share-input" />
-          <div className="kaiju-Share-info">Users will have 24 hours to activate this link and become a collaborator</div>
-        </Modal>
-      </MenuItem>
-    );
-  }
-}
-
-ShareMenuItem.propTypes = propTypes;
+const ShareMenuItem = props => (
+  <li>
+    <Share {...props}>
+      <div className={cx('title')}>Share</div>
+    </Share>
+  </li>
+);
 
 const mapStateToProps = ({ project }) => ({
   collaborationInvitation: project.collaborationInvitationUrl,
+  readOnlyUrl: project.url,
+  type: 'PROJECT',
 });
 
 export default connect(mapStateToProps)(ShareMenuItem);

--- a/rails/client/app/bundles/kaiju/components/Project/containers/menu/ShareMenuItem.scss
+++ b/rails/client/app/bundles/kaiju/components/Project/containers/menu/ShareMenuItem.scss
@@ -1,0 +1,10 @@
+:local {
+  .title {
+    border-bottom: 1px solid #111;
+    padding: 10px;
+
+    &:hover {
+      background-color: var(--kaiju-theme-hover-active, #282828);
+    }
+  }
+}


### PR DESCRIPTION
### Summary
Reworked the UI of the share menu and added a Read-Only share option.

Previous UI:
![image](https://user-images.githubusercontent.com/6720991/36680188-a6060088-1ada-11e8-91d1-a3b0f03953c0.png)

Updated UI:
![image](https://user-images.githubusercontent.com/6720991/36680199-b4e2283e-1ada-11e8-8838-740437f059c4.png)

Resolves #106 

Thanks for contributing to Kaiju.
@cerner/kaiju

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
