### PR TITLE
Updated - Removed editable actions from the ActionBar when viewing is read-only

### DIFF
--- a/rails/client/app/bundles/kaiju/components/Project/components/ActionBar/ActionBar.jsx
+++ b/rails/client/app/bundles/kaiju/components/Project/components/ActionBar/ActionBar.jsx
@@ -15,27 +15,31 @@ import './ActionBar.scss';
 
 const propTypes = {
   /**
-   * The canvas size
+   * The canvas size.
    */
   canvasSize: PropTypes.string,
   /**
-   * Callback function triggered when a workspace is deleted
+   * Whether the workspace is editable.
+   */
+  isEditable: PropTypes.bool,
+  /**
+   * Callback function triggered when a workspace is deleted.
    */
   onDelete: PropTypes.func,
   /**
-   * Callback function triggered when a workspace is renamed
+   * Callback function triggered when a workspace is renamed.
    */
   onRename: PropTypes.func,
   /**
-   * Callback function triggered when the canvas is resized
+   * Callback function triggered when the canvas is resized.
    */
   onResize: PropTypes.func,
   /**
-   * The currently selected component
+   * The currently selected component.
    */
   selectedComponent: PropTypes.object,
   /**
-   * The current workspace
+   * The current workspace.
    */
   workspace: PropTypes.object,
 };
@@ -131,8 +135,16 @@ class ActionBar extends React.Component {
   }
 
   render() {
-    const { canvasSize, onRename, onDelete, onResize, selectedComponent, workspace } = this.props;
-    const { codeUrl, component, collaborationInvitation, id, name, previewUrl, rename, url } = workspace;
+    const {
+      canvasSize,
+      isEditable,
+      onRename,
+      onDelete,
+      onResize,
+      selectedComponent,
+      workspace,
+    } = this.props;
+    const { id, url, name, rename, codeUrl, component, previewUrl, collaborationInvitation } = workspace;
     const navigateToCode = () => window.open(codeUrl, '_blank');
     const navigateToPreview = () => window.open(previewUrl, '_blank');
     const navigateToAttributes = () => window.open(`${selectedComponent ? selectedComponent.url : component.url}/attributes`, '_blank');
@@ -140,26 +152,36 @@ class ActionBar extends React.Component {
     return (
       <div className="kaiju-ActionBar">
         <div className="kaiju-ActionBar-actions">
-          <ActionItem title="Undo" onClick={this.undo}>
-            <IconUndo />
-          </ActionItem>
-          <ActionItem title="Redo" onClick={this.redo}>
-            <IconRedo />
-          </ActionItem>
-          <ActionItem title="Rename">
-            <Rename onRename={newName => onRename(id, newName)} renameUrl={rename} workspaceName={name} />
-          </ActionItem>
+          { isEditable &&
+            <ActionItem title="Undo" onClick={this.undo}>
+              <IconUndo />
+            </ActionItem>
+          }
+          { isEditable &&
+            <ActionItem title="Redo" onClick={this.redo}>
+              <IconRedo />
+            </ActionItem>
+          }
+          { isEditable &&
+            <ActionItem title="Rename">
+              <Rename onRename={newName => onRename(id, newName)} renameUrl={rename} workspaceName={name} />
+            </ActionItem>
+          }
           <ActionItem title="Duplicate">
             <Duplicate />
           </ActionItem>
-          <ActionItem title="Delete">
-            <Delete url={url} workspaceName={name} onDelete={() => onDelete(id)} />
-          </ActionItem>
+          { isEditable &&
+            <ActionItem title="Delete">
+              <Delete url={url} workspaceName={name} onDelete={() => onDelete(id)} />
+            </ActionItem>
+          }
           <ActionItem iconType="code-o" onClick={navigateToCode} title="Code" />
           <ActionItem iconType="bars" onClick={navigateToAttributes} title="Attributes" />
-          <ActionItem title="Share">
-            <Share collaborationInvitation={collaborationInvitation} readOnlyUrl={workspace.url} type="WORKSPACE" />
-          </ActionItem>
+          { isEditable &&
+            <ActionItem title="Share">
+              <Share collaborationInvitation={collaborationInvitation} readOnlyUrl={workspace.url} type="WORKSPACE" />
+            </ActionItem>
+          }
           <ActionItem iconType="eye-o" onClick={navigateToPreview} title="Preview" />
           <SizeControl onChange={onResize} selectedSize={canvasSize} />
         </div>

--- a/rails/client/app/bundles/kaiju/components/Project/components/ActionBar/ActionBar.jsx
+++ b/rails/client/app/bundles/kaiju/components/Project/components/ActionBar/ActionBar.jsx
@@ -63,13 +63,16 @@ class ActionBar extends React.Component {
 
   componentDidMount() {
     Mousetrap.bind(['command+c', 'ctrl+c'], copy);
-    Mousetrap.bind(['command+v', 'ctrl+v'], paste);
-    Mousetrap.bind(['command+z', 'ctrl+z'], this.undo);
-    Mousetrap.bind(['command+shift+z', 'ctrl+shift+z'], this.redo);
-    Mousetrap.bind(['backspace', 'delete'], ActionBar.destroy);
     Mousetrap.bind(['esc'], ActionBar.deselect);
-    Mousetrap.bind(['command+d', 'ctrl+d'], this.duplicate);
-    window.addEventListener('message', this.handleShortcuts);
+
+    if (this.props.isEditable) {
+      Mousetrap.bind(['command+v', 'ctrl+v'], paste);
+      Mousetrap.bind(['command+z', 'ctrl+z'], this.undo);
+      Mousetrap.bind(['command+shift+z', 'ctrl+shift+z'], this.redo);
+      Mousetrap.bind(['backspace', 'delete'], ActionBar.destroy);
+      Mousetrap.bind(['command+d', 'ctrl+d'], this.duplicate);
+      window.addEventListener('message', this.handleShortcuts);
+    }
   }
 
   componentWillUnmount() {

--- a/rails/client/app/bundles/kaiju/components/Project/components/ActionBar/ActionBar.jsx
+++ b/rails/client/app/bundles/kaiju/components/Project/components/ActionBar/ActionBar.jsx
@@ -155,17 +155,20 @@ class ActionBar extends React.Component {
     return (
       <div className="kaiju-ActionBar">
         <div className="kaiju-ActionBar-actions">
-          { isEditable &&
+          {
+            isEditable &&
             <ActionItem title="Undo" onClick={this.undo}>
               <IconUndo />
             </ActionItem>
           }
-          { isEditable &&
+          {
+            isEditable &&
             <ActionItem title="Redo" onClick={this.redo}>
               <IconRedo />
             </ActionItem>
           }
-          { isEditable &&
+          {
+            isEditable &&
             <ActionItem title="Rename">
               <Rename onRename={newName => onRename(id, newName)} renameUrl={rename} workspaceName={name} />
             </ActionItem>
@@ -173,14 +176,16 @@ class ActionBar extends React.Component {
           <ActionItem title="Duplicate">
             <Duplicate />
           </ActionItem>
-          { isEditable &&
+          {
+            isEditable &&
             <ActionItem title="Delete">
               <Delete url={url} workspaceName={name} onDelete={() => onDelete(id)} />
             </ActionItem>
           }
           <ActionItem iconType="code-o" onClick={navigateToCode} title="Code" />
           <ActionItem iconType="bars" onClick={navigateToAttributes} title="Attributes" />
-          { isEditable &&
+          {
+            isEditable &&
             <ActionItem title="Share">
               <Share collaborationInvitation={collaborationInvitation} readOnlyUrl={workspace.url} type="WORKSPACE" />
             </ActionItem>

--- a/rails/client/app/bundles/kaiju/components/Project/components/Sandbox/Sandbox.jsx
+++ b/rails/client/app/bundles/kaiju/components/Project/components/Sandbox/Sandbox.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
-import ActionBar from '../ActionBar/ActionBar';
+import ActionBarContainer from '../../containers/ActionBarContainer';
 import Alert from '../../../common/Alert/Alert';
 import styles from './Sandbox.scss';
 
@@ -9,29 +9,17 @@ const cx = classNames.bind(styles);
 
 const propTypes = {
   /**
-   * The current canvas size
+   * The current canvas size.
    */
   canvasSize: PropTypes.string,
   /**
-   * Callback function triggered when the Workpsace is deleted
+   * The component URL.
    */
-  onDelete: PropTypes.func,
+  componentUrl: PropTypes.string,
   /**
-   * Callback function triggered when the Workpsace is renamed
+   * Whether the workspace is read-nly.
    */
-  onRename: PropTypes.func,
-  /**
-   * Callback function triggered when the canvas is resized
-   */
-  onResize: PropTypes.func,
-  /**
-   * The currently selected component
-   */
-  selectedComponent: PropTypes.object,
-  /**
-   * The current open Workspace
-   */
-  workspace: PropTypes.object,
+  isReadOnly: PropTypes.bool,
 };
 
 class Sandbox extends React.Component {
@@ -40,35 +28,26 @@ class Sandbox extends React.Component {
   }
 
   render() {
-    const {
-      canvasSize,
-      onDelete,
-      onRename,
-      onResize,
-      selectedComponent,
-      workspace,
-    } = this.props;
+    const { canvasSize, componentUrl, isReadOnly } = this.props;
 
     return (
       <div className={cx('sandbox')}>
-        { !workspace.isEditable && <Alert title="Read-only view." description="You are not authorized to edit this workspace." /> }
+        { isReadOnly &&
+          <Alert
+            title="Read-only view."
+            description="You are not authorized to edit this workspace."
+          />
+        }
         <div className={cx('content')}>
           <div className={cx('container')}>
             <iframe
               id="kaiju-Sandbox-iframe"
               className={cx('iframe', canvasSize)}
-              src={workspace.component.url}
+              src={componentUrl}
               title="sandbox"
             />
           </div>
-          <ActionBar
-            canvasSize={canvasSize}
-            onDelete={onDelete}
-            onRename={onRename}
-            onResize={onResize}
-            workspace={workspace}
-            selectedComponent={selectedComponent}
-          />
+          <ActionBarContainer />
         </div>
       </div>
     );

--- a/rails/client/app/bundles/kaiju/components/Project/components/Sandbox/Sandbox.jsx
+++ b/rails/client/app/bundles/kaiju/components/Project/components/Sandbox/Sandbox.jsx
@@ -32,7 +32,8 @@ class Sandbox extends React.Component {
 
     return (
       <div className={cx('sandbox')}>
-        { isReadOnly &&
+        {
+          isReadOnly &&
           <Alert
             title="Read-only view."
             description="You are not authorized to edit this workspace."

--- a/rails/client/app/bundles/kaiju/components/Project/containers/ActionBarContainer.jsx
+++ b/rails/client/app/bundles/kaiju/components/Project/containers/ActionBarContainer.jsx
@@ -1,0 +1,24 @@
+import { connect } from 'react-redux';
+import { setCanvasSize, removeWorkspace, renameWorkspace } from '../actions/actions';
+import ActionBar from '../components/ActionBar/ActionBar';
+
+const mapStateToProps = ({ activeWorkspace, canvasSize, components, selectedComponent, workspaces }) => ({
+  canvasSize,
+  isEditable: workspaces[activeWorkspace].isEditable,
+  selectedComponent: components[selectedComponent],
+  workspace: workspaces[activeWorkspace],
+});
+
+const mapDispatchToProps = dispatch => ({
+  onDelete: (id) => {
+    dispatch(removeWorkspace(id));
+  },
+  onRename: (id, name) => {
+    dispatch(renameWorkspace(id, name));
+  },
+  onResize: (size) => {
+    dispatch(setCanvasSize(size));
+  },
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(ActionBar);

--- a/rails/client/app/bundles/kaiju/components/Project/containers/SandboxContainer.jsx
+++ b/rails/client/app/bundles/kaiju/components/Project/containers/SandboxContainer.jsx
@@ -1,23 +1,10 @@
 import { connect } from 'react-redux';
-import { setCanvasSize, removeWorkspace, renameWorkspace } from '../actions/actions';
 import Sandbox from '../components/Sandbox/Sandbox';
 
-const mapStateToProps = ({ activeWorkspace, canvasSize, components, selectedComponent, workspaces }) => ({
+const mapStateToProps = ({ activeWorkspace, canvasSize, workspaces }) => ({
   canvasSize,
-  selectedComponent: components[selectedComponent],
-  workspace: workspaces[activeWorkspace],
+  componentUrl: workspaces[activeWorkspace].component.url,
+  isReadOnly: !workspaces[activeWorkspace].isEditable,
 });
 
-const mapDispatchToProps = dispatch => ({
-  onDelete: (id) => {
-    dispatch(removeWorkspace(id));
-  },
-  onRename: (id, name) => {
-    dispatch(renameWorkspace(id, name));
-  },
-  onResize: (size) => {
-    dispatch(setCanvasSize(size));
-  },
-});
-
-export default connect(mapStateToProps, mapDispatchToProps)(Sandbox);
+export default connect(mapStateToProps)(Sandbox);

--- a/rails/client/webpack.config.js
+++ b/rails/client/webpack.config.js
@@ -112,7 +112,9 @@ const config = {
                         'iOS >= 8',
                       ],
                     }),
-                    CustomProperties(),
+                    CustomProperties({
+                      warnings: false,
+                    }),
                   ];
                 },
               },


### PR DESCRIPTION
### Summary
#### Previous
![image](https://user-images.githubusercontent.com/6720991/36818157-738eb9e4-1ca9-11e8-8dfc-8b760afd7b67.png)

#### Updated
![image](https://user-images.githubusercontent.com/6720991/36818116-475962b6-1ca9-11e8-879c-610158afc7d9.png)


Resolves #110.

Thanks for contributing to Kaiju.
@cerner/kaiju

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
