### PR TITLE
Fix - Browser navigation stack

### DIFF
--- a/rails/client/app/bundles/kaiju/components/Project/containers/BrowserContainer.jsx
+++ b/rails/client/app/bundles/kaiju/components/Project/containers/BrowserContainer.jsx
@@ -7,7 +7,7 @@ import TabContainer from './TabContainer';
 import Tabs from '../components/Tabs/Tabs';
 
 const getTabs = (activeWorkspace, project, workspaces, workspaceTabs) => {
-  history.pushState({}, '', activeWorkspace ? workspaces[activeWorkspace].url : project.url);
+  history.replaceState({}, '', activeWorkspace ? workspaces[activeWorkspace].url : project.url);
 
   const tabs = Array.from(workspaceTabs).map((id, index, array) => (
     <TabContainer key={id} id={id} next={array[index + 1] || null} />


### PR DESCRIPTION
### Summary
Users were running into issues with the default browser navigation actions. ( Back and Forward ). 

Kaiju updates the browser URL as workspaces are opened and closed so that the web url will always match the current workspace or project. This is done by pushing urls onto the browser history stack.

This resulted in creating really long navigation stacks as the user opened and closed tabs.
```
/workspace/1
/workspace/2
/workspace/4
/workspace/1
```

To fix this issue the URL will no longer be pushed onto the history stack, but rather replace the current stack index. This makes the single page navigation more intuitive. The stack no longer grows, clicking back will always take a user to the previous web url before they opened a Kaiju workspace or project regardless of how many workspaces they opened and closed. 

Steps to test / reproduce:
1. Open a Kaiju project
2. Open a workspace
3. Open and close additional workspaces from the Kaiju tab system
4. Press back within the browser

https://developer.mozilla.org/en-US/docs/Web/API/History_API

Thanks for contributing to Kaiju.
@cerner/kaiju

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
