### PR TITLE
Added - Native hover titles to Cards and Tabs

### DIFF
--- a/rails/client/app/bundles/kaiju/components/Project/components/Tabs/Tab/Tab.jsx
+++ b/rails/client/app/bundles/kaiju/components/Project/components/Tabs/Tab/Tab.jsx
@@ -1,51 +1,56 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
+import classNames from 'classnames/bind';
 import IconClose from 'terra-icon/lib/icon/IconClose';
-import './Tab.scss';
+import styles from './Tab.scss';
+
+const cx = classNames.bind(styles);
 
 const propTypes = {
   /**
-   * Content to be displayed within the Tab
+   * Content to be displayed within the Tab.
    */
   children: PropTypes.node,
   /**
-   * Whether the tab is selected
+   * Whether the tab is selected.
    */
   isSelected: PropTypes.bool,
   /**
-   * Callback for click events
+   * Callback for click events.
    */
   onClick: PropTypes.func,
   /**
-   * Callback for double click events
+   * Callback for double click events.
    */
   onDoubleClick: PropTypes.func,
   /**
-   * Callback for requesting to close
+   * Callback for requesting to close.
    */
   onRequestClose: PropTypes.func,
+  /**
+   * Title of the tab.
+   */
+  title: PropTypes.string,
 };
 
-const Tab = ({ children, isSelected, onClick, onDoubleClick, onRequestClose }) => {
+const Tab = ({ children, isSelected, onClick, onDoubleClick, onRequestClose, title }) => {
   /**
-   * Handler for the close button
-   * @param {Object} event - The event invoking the function
-   * @return undefined
+   * Handler for the close button.
+   * @param {event} event - The event invoking the function.
    */
   const handleClose = (event) => {
-    // Prevents the event from bubbling up and invoking onClick
+    // Prevents the event from bubbling up and invoking onClick.
     event.stopPropagation();
     onRequestClose(event);
   };
 
-  const classes = classNames(['kaiju-Tab', { 'is-selected': isSelected }]);
+  const classes = cx('tab', { 'is-selected': isSelected });
   return (
-    <li className={classes} onClick={onClick} onDoubleClick={onDoubleClick} role="tab">
-      <span className="kaiju-Tab-content">
+    <li className={classes} onClick={onClick} onDoubleClick={onDoubleClick} role="tab" title={title}>
+      <span className={cx('content')}>
         {children}
       </span>
-      <div className="kaiju-Tab-closeButton" onClick={handleClose} role="presentation">
+      <div className={cx('close')} onClick={handleClose} role="presentation" title="Close">
         {onRequestClose && <IconClose />}
       </div>
     </li>

--- a/rails/client/app/bundles/kaiju/components/Project/components/Tabs/Tab/Tab.scss
+++ b/rails/client/app/bundles/kaiju/components/Project/components/Tabs/Tab/Tab.scss
@@ -1,53 +1,55 @@
-.kaiju-Tab {
-  align-content: center;
-  align-items: center;
-  background-color: var(--kaiju-theme-background-color, #222);
-  border-right: 1px solid #111;
-  color: var(--kaiju-theme-font-color, #fff);
-  cursor: default;
-  display: flex;
-  flex: 1 1 0;
-  max-width: 140px;
-  min-width: 10px;
-  padding: 8px 0;
-  position: relative;
-
-  &:hover {
-    background-color: var(--kaiju-theme-hover-active, #282828);
-
-    > .kaiju-Tab-closeButton {
-      display: inherit;
-    }
-  }
-
-  &.is-selected {
-    background-color: var(--kaiju-theme-background-secondary-color, #333);
-
-    > .kaiju-Tab-content {
-      opacity: 1;
-    }
+:local {
+  .tab {
+    align-content: center;
+    align-items: center;
+    background-color: var(--kaiju-theme-background-color, #222);
+    border-right: 1px solid #111;
+    color: var(--kaiju-theme-font-color, #fff);
+    cursor: default;
+    display: flex;
+    flex: 1 1 0;
+    max-width: 140px;
+    min-width: 10px;
+    padding: 8px 0;
+    position: relative;
 
     &:hover {
+      background-color: var(--kaiju-theme-hover-active, #282828);
+
+      > .close {
+        display: inherit;
+      }
+    }
+
+    &.is-selected {
       background-color: var(--kaiju-theme-background-secondary-color, #333);
+
+      > .content {
+        opacity: 1;
+      }
+
+      &:hover {
+        background-color: var(--kaiju-theme-background-secondary-color, #333);
+      }
     }
   }
-}
 
-.kaiju-Tab-content {
-  flex: 1 1 0;
-  opacity: 0.5;
-  overflow: hidden;
-  padding: 0 10px;
-  text-align: center;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
+  .content {
+    flex: 1 1 0;
+    opacity: 0.5;
+    overflow: hidden;
+    padding: 0 10px;
+    text-align: center;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
 
-.kaiju-Tab-closeButton {
-  background-color: inherit;
-  display: none;
-  margin-right: 5px;
-  padding: 2px;
-  position: absolute;
-  right: 0;
+  .close {
+    background-color: inherit;
+    display: none;
+    margin-right: 5px;
+    padding: 2px;
+    position: absolute;
+    right: 0;
+  }
 }

--- a/rails/client/app/bundles/kaiju/components/Project/containers/TabContainer.jsx
+++ b/rails/client/app/bundles/kaiju/components/Project/containers/TabContainer.jsx
@@ -118,6 +118,7 @@ const mapStateToProps = ({ activeWorkspace, workspaces }, { id }) => ({
   name: id ? workspaces[id].name : '+',
   isSelected: activeWorkspace === id,
   renameUrl: id ? workspaces[id].rename : null,
+  title: id ? workspaces[id].name : null,
 });
 
 const mapDispatchToProps = (dispatch, { id, next }) => ({

--- a/rails/client/app/bundles/kaiju/components/common/Card/Card.jsx
+++ b/rails/client/app/bundles/kaiju/components/common/Card/Card.jsx
@@ -32,7 +32,7 @@ const propTypes = {
 };
 
 const Card = ({ author, isOpen, name, onClick, project, updateDateTime }) => (
-  <div className={classNames(['kaiju-Card', { 'is-open': isOpen }])} onClick={onClick} role="presentation">
+  <div className={classNames(['kaiju-Card', { 'is-open': isOpen }])} onClick={onClick} role="presentation" title={name}>
     <div className="kaiju-Card-details">
       { project && <div className="kaiju-Card-project">{project}</div> }
       <div className="kaiju-Card-name">{name}</div>


### PR DESCRIPTION
### Summary
This change adds a title to Cards and Tabs to display the full text when hovered. This change also updates the Tab to use css modules.

Resolves #117 

### Additional Details
This is a browser native title. The title will display after hovering the items for ~2 seconds.

Thanks for contributing to Kaiju.
@cerner/kaiju

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
