### PR TITLE
Updated - Uplifted Ant Design to 3.0

### DIFF
--- a/rails/client/.babelrc
+++ b/rails/client/.babelrc
@@ -10,7 +10,7 @@
       "import",
       {
         "libraryName": "antd",
-        "style": "css"
+        "style": true
       }
     ]
   ]

--- a/rails/client/app/bundles/kaiju/components/Project/Project.jsx
+++ b/rails/client/app/bundles/kaiju/components/Project/Project.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Provider } from 'react-redux';
 import { camelizeKeys } from 'humps';
+import 'antd/lib/style/v2-compatible-reset.css';
 import { setReferenceComponents, updateComponent } from './actions/actions';
 import configureStore from './store/projectStore';
 import BrowserContainer from './containers/BrowserContainer';

--- a/rails/client/app/bundles/kaiju/components/Project/components/ActionBar/Delete/Delete.jsx
+++ b/rails/client/app/bundles/kaiju/components/Project/components/ActionBar/Delete/Delete.jsx
@@ -37,14 +37,22 @@ class Rename extends React.Component {
   }
 
   render() {
-    return (
-      <div className="kaiju-DeleteWorkspace" onClick={this.showModal} role="presentation">
+    return [
+      <div key="delete" className="kaiju-DeleteWorkspace" onClick={this.showModal} role="presentation">
         <Icon type="delete" />
-        <Modal title="Delete Workspace" visible={this.state.isOpen} cancelText="Cancel" okText="Confirm" onCancel={this.handleCancel} onOk={this.handleConfirm}>
-          <div className="kaiju-DeleteWorkspace-message">Are you sure you want to delete this workspace?</div>
-        </Modal>
-      </div>
-    );
+      </div>,
+      <Modal
+        key="delete-modal"
+        okText="Confirm"
+        cancelText="Cancel"
+        title="Delete Workspace"
+        onCancel={this.handleCancel}
+        onOk={this.handleConfirm}
+        visible={this.state.isOpen}
+      >
+        <div className="kaiju-DeleteWorkspace-message">Are you sure you want to delete this workspace?</div>
+      </Modal>,
+    ];
   }
 }
 

--- a/rails/client/app/bundles/kaiju/components/Project/components/ActionBar/Duplicate/Duplicate.jsx
+++ b/rails/client/app/bundles/kaiju/components/Project/components/ActionBar/Duplicate/Duplicate.jsx
@@ -163,7 +163,7 @@ class Duplicate extends React.Component {
     this.setState({ isOpen: true, projects: null, name: `${this.state.name} Copy` });
 
     // The input can only be selected when the modal has finished animating.
-    setTimeout(() => { this.input.refs.input.select(); }, 200);
+    setTimeout(() => { this.input.input.select(); }, 200);
 
     axios
      .get(this.props.projectsUrl)
@@ -213,25 +213,26 @@ class Duplicate extends React.Component {
       );
     }
 
-    return (
-      <div onClick={this.showModal} role="presentation">
+    return [
+      <div key="duplicate" onClick={this.showModal} role="presentation">
         <Icon type="copy" />
-        <Modal
-          width="725px"
-          title="Duplicate"
-          visible={isOpen}
-          onCancel={this.handleCancel}
-          onOk={this.handleConfirm}
-          okText="Confirm"
-          cancelText="Cancel"
-        >
-          <div className={cx('description')}>Workspace Name:</div>
-          <Input value={this.state.name} onChange={this.handleNameChange} ref={(input) => { this.input = input; }} />
-          <div className={cx('description')}>Workspace Destination:</div>
-          {content}
-        </Modal>
-      </div>
-    );
+      </div>,
+      <Modal
+        key="duplicate-modal"
+        width="725px"
+        title="Duplicate"
+        okText="Confirm"
+        cancelText="Cancel"
+        visible={isOpen}
+        onCancel={this.handleCancel}
+        onOk={this.handleConfirm}
+      >
+        <div className={cx('description')}>Workspace Name:</div>
+        <Input value={this.state.name} onChange={this.handleNameChange} ref={(input) => { this.input = input; }} />
+        <div className={cx('description')}>Workspace Destination:</div>
+        {content}
+      </Modal>,
+    ];
   }
 }
 

--- a/rails/client/app/bundles/kaiju/components/Project/components/ActionBar/Rename/Rename.jsx
+++ b/rails/client/app/bundles/kaiju/components/Project/components/ActionBar/Rename/Rename.jsx
@@ -72,31 +72,37 @@ class Rename extends React.Component {
     this.setState({ isOpen: true });
 
     // The input can only be selected when the modal has finished animating
-    setTimeout(() => { this.input.refs.input.select(); }, 200);
+    setTimeout(() => { this.input.input.select(); }, 200);
   }
 
   render() {
-    return (
-      <div className="kaiju-RenameWorkspace" onClick={this.showModal} role="presentation">
+    return [
+      <div
+        key="rename"
+        className="kaiju-RenameWorkspace"
+        onClick={this.showModal}
+        role="presentation"
+      >
         <Icon type="edit" />
-        <Modal
-          title="Rename Workspace"
-          cancelText="Cancel"
-          okText="Save"
-          onCancel={this.handleCancel}
-          onOk={this.handleSave}
-          visible={this.state.isOpen}
-        >
-          <div className="kaiju-RenameWorkspace-name">Workspace Name:</div>
-          <Input
-            value={this.state.name}
-            onChange={this.handleNameChange}
-            onPressEnter={this.handleSave}
-            ref={(input) => { this.input = input; }}
-          />
-        </Modal>
-      </div>
-    );
+      </div>,
+      <Modal
+        key="rename-modal"
+        title="Rename Workspace"
+        cancelText="Cancel"
+        okText="Save"
+        onCancel={this.handleCancel}
+        onOk={this.handleSave}
+        visible={this.state.isOpen}
+      >
+        <div className="kaiju-RenameWorkspace-name">Workspace Name:</div>
+        <Input
+          value={this.state.name}
+          onChange={this.handleNameChange}
+          onPressEnter={this.handleSave}
+          ref={(input) => { this.input = input; }}
+        />
+      </Modal>,
+    ];
   }
 }
 

--- a/rails/client/app/bundles/kaiju/components/Project/components/ActionBar/Share/Share.jsx
+++ b/rails/client/app/bundles/kaiju/components/Project/components/ActionBar/Share/Share.jsx
@@ -83,7 +83,7 @@ class Share extends React.Component {
    * Selects the share invitation text.
    */
   select() {
-    this.input.refs.input.select();
+    this.input.input.select();
   }
 
   /**
@@ -133,22 +133,28 @@ class Share extends React.Component {
       </CopyToClipboard>
     );
 
-    return (
-      <div onClick={this.showModal} role="presentation">
+    return [
+      <div key="share" onClick={this.showModal} role="presentation">
         {children || <Icon type="share-alt" />}
-        <Modal title={Descriptions[type].TITLE} onCancel={this.handleCancel} visible={isOpen} footer={null}>
-          <Magician key={permissions}>
-            <h2 className={cx('title')}>{Descriptions[permissions].TITLE}</h2>
-            <p className={cx('description')}>{Descriptions[type][permissions]}</p>
-            <Input readOnly value={value} addonAfter={addon} onFocus={this.select} ref={this.ref} />
-            {isShareable && <div className={cx('info')}>{Descriptions[type].INFO}</div>}
-            <div className={cx('toggle', { 'is-edit': isShareable })} onClick={this.togglePermissions} role="presentation">
+      </div>,
+      <Modal
+        key="share-modal"
+        title={Descriptions[type].TITLE}
+        onCancel={this.handleCancel}
+        visible={isOpen}
+        footer={null}
+      >
+        <Magician key={permissions}>
+          <h3 className={cx('title')}>{Descriptions[permissions].TITLE}</h3>
+          <p className={cx('description')}>{Descriptions[type][permissions]}</p>
+          <Input readOnly value={value} addonAfter={addon} onFocus={this.select} ref={this.ref} />
+          {isShareable && <div className={cx('info')}>{Descriptions[type].INFO}</div>}
+          <div className={cx('toggle', { 'is-edit': isShareable })} onClick={this.togglePermissions} role="presentation">
               Get a {Descriptions[permissions].ALT} <Icon type={isShareable ? 'eye-o' : 'edit'} />
-            </div>
-          </Magician>
-        </Modal>
-      </div>
-    );
+          </div>
+        </Magician>
+      </Modal>,
+    ];
   }
 }
 

--- a/rails/client/app/bundles/kaiju/components/Project/components/Form/Item/Item.scss
+++ b/rails/client/app/bundles/kaiju/components/Project/components/Form/Item/Item.scss
@@ -4,8 +4,14 @@
   // Disabling to allow custom ant styles
   // stylelint-disable
   .ant-form-item-label {
+    line-height: 2;
+
     label {
       color: var(--kaiju-theme-font-color, #fff) !important;
     }
+  }
+
+  .ant-form-item-control {
+    line-height: 2;
   }
 }

--- a/rails/client/app/bundles/kaiju/components/Project/components/Menu/Menu.scss
+++ b/rails/client/app/bundles/kaiju/components/Project/components/Menu/Menu.scss
@@ -2,7 +2,9 @@
   align-items: stretch;
   cursor: default;
   display: flex;
+  margin-bottom: 0;
   margin-left: 5px;
+  padding-left: 0;
 
   > .kaiju-MenuItem {
     margin: 0 5px;

--- a/rails/client/app/bundles/kaiju/components/Project/components/Menu/MenuItem/MenuItem.scss
+++ b/rails/client/app/bundles/kaiju/components/Project/components/Menu/MenuItem/MenuItem.scss
@@ -1,5 +1,6 @@
 .kaiju-MenuItem {
   align-items: center;
+  cursor: pointer;
   display: flex;
 
   > .kaiju-SubMenu {

--- a/rails/client/app/bundles/kaiju/components/Project/components/Menu/SubMenu/SubMenu.scss
+++ b/rails/client/app/bundles/kaiju/components/Project/components/Menu/SubMenu/SubMenu.scss
@@ -4,6 +4,8 @@
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.6);
   display: flex;
   flex-direction: column;
+  margin: 0;
+  padding-left: 0;
   position: absolute;
   // TODO: Adjust this to not be hard coded
   top: 33px;

--- a/rails/client/app/bundles/kaiju/components/Project/components/Tabs/Tabs.scss
+++ b/rails/client/app/bundles/kaiju/components/Project/components/Tabs/Tabs.scss
@@ -2,4 +2,6 @@
   background-color: var(--kaiju-theme-background-color, #222);
   display: flex;
   flex: 1 1 0;
+  margin: 0;
+  padding-left: 0;
 }

--- a/rails/client/app/bundles/kaiju/components/Project/containers/ProjectNameContainer.jsx
+++ b/rails/client/app/bundles/kaiju/components/Project/containers/ProjectNameContainer.jsx
@@ -79,26 +79,26 @@ class ProjectName extends React.Component {
   render() {
     document.title = this.props.name;
 
-    return (
+    return [
       <span onClick={this.showModal} role="presentation">
         {this.props.name}
-        <Modal
-          title="Rename Project"
-          cancelText="Cancel"
-          okText="Save"
-          onCancel={this.handleCancel}
-          onOk={this.handleSave}
-          visible={this.state.isOpen}
-        >
-          <Input
-            value={this.state.name}
-            onChange={this.handleNameChange}
-            onPressEnter={this.handleSave}
-            ref={(input) => { if (input) { this.input = input.refs.input; } }}
-          />
-        </Modal>
-      </span>
-    );
+      </span>,
+      <Modal
+        title="Rename Project"
+        cancelText="Cancel"
+        okText="Save"
+        onCancel={this.handleCancel}
+        onOk={this.handleSave}
+        visible={this.state.isOpen}
+      >
+        <Input
+          value={this.state.name}
+          onChange={this.handleNameChange}
+          onPressEnter={this.handleSave}
+          ref={(input) => { if (input) { this.input = input.input; } }}
+        />
+      </Modal>,
+    ];
   }
 }
 

--- a/rails/client/app/bundles/kaiju/components/Project/containers/ProjectNameContainer.jsx
+++ b/rails/client/app/bundles/kaiju/components/Project/containers/ProjectNameContainer.jsx
@@ -80,10 +80,11 @@ class ProjectName extends React.Component {
     document.title = this.props.name;
 
     return [
-      <span onClick={this.showModal} role="presentation">
+      <span key="project-name" onClick={this.showModal} role="presentation">
         {this.props.name}
       </span>,
       <Modal
+        key="project-modal"
         title="Rename Project"
         cancelText="Cancel"
         okText="Save"

--- a/rails/client/app/bundles/kaiju/components/Project/containers/TabContainer.jsx
+++ b/rails/client/app/bundles/kaiju/components/Project/containers/TabContainer.jsx
@@ -86,12 +86,10 @@ class TabContainer extends React.Component {
     }
 
     return (
-      <Tab
-        onDoubleClick={this.showModal}
-        role="presentation"
-        {...tabProperties}
-      >
-        {name}
+      <Tab {...tabProperties}>
+        <span onDoubleClick={this.showModal} role="presentation">
+          {name}
+        </span>
         <Modal
           title="Rename Workspace"
           cancelText="Cancel"
@@ -104,7 +102,7 @@ class TabContainer extends React.Component {
             value={this.state.name}
             onChange={this.handleNameChange}
             onPressEnter={this.handleSave}
-            ref={(input) => { if (input) { this.input = input.refs.input; } }}
+            ref={(input) => { if (input) { this.input = input.input; } }}
           />
         </Modal>
       </Tab>

--- a/rails/client/app/bundles/kaiju/components/Project/containers/menu/DeleteMenuItem.jsx
+++ b/rails/client/app/bundles/kaiju/components/Project/containers/menu/DeleteMenuItem.jsx
@@ -35,13 +35,22 @@ class DeleteMenuItem extends React.Component {
   }
 
   render() {
-    return (
-      <MenuItem title="Delete" onClick={this.showModal}>
-        <Modal title="Delete Project" visible={this.state.isOpen} cancelText="Cancel" okText="Confirm" onCancel={this.handleCancel} onOk={this.handleConfirm}>
-          <div className="kaiju-DeleteProject-message">Are you sure you want to delete this project?</div>
-        </Modal>
-      </MenuItem>
-    );
+    return [
+      <MenuItem key="delete" title="Delete" onClick={this.showModal} />,
+      <Modal
+        key="delete-modal"
+        title="Delete Project"
+        cancelText="Cancel"
+        okText="Confirm"
+        visible={this.state.isOpen}
+        onCancel={this.handleCancel}
+        onOk={this.handleConfirm}
+      >
+        <div className="kaiju-DeleteProject-message">
+          Are you sure you want to delete this project?
+        </div>
+      </Modal>,
+    ];
   }
 }
 

--- a/rails/client/app/bundles/kaiju/components/Project/containers/menu/OpenMenuItem.jsx
+++ b/rails/client/app/bundles/kaiju/components/Project/containers/menu/OpenMenuItem.jsx
@@ -52,13 +52,19 @@ class OpenMenuItem extends React.Component {
   }
 
   render() {
-    return (
-      <MenuItem title="Open..." onClick={this.showModal}>
-        <Modal width="725px" title="Open..." visible={this.state.isOpen} onCancel={this.handleCancel} footer={null}>
-          {this.state.content}
-        </Modal>
-      </MenuItem>
-    );
+    return [
+      <MenuItem key="open" title="Open..." onClick={this.showModal} />,
+      <Modal
+        key="open-modal"
+        width="745px"
+        title="Open..."
+        visible={this.state.isOpen}
+        onCancel={this.handleCancel}
+        footer={null}
+      >
+        {this.state.content}
+      </Modal>,
+    ];
   }
 }
 

--- a/rails/client/app/bundles/kaiju/components/Project/containers/menu/RenameMenuItem.jsx
+++ b/rails/client/app/bundles/kaiju/components/Project/containers/menu/RenameMenuItem.jsx
@@ -79,25 +79,25 @@ class RenameMenuItem extends React.Component {
 
 
   render() {
-    return (
-      <MenuItem title="Rename" onClick={this.showModal}>
-        <Modal
-          title="Rename Project"
-          cancelText="Cancel"
-          okText="Save"
-          onCancel={this.handleCancel}
-          onOk={this.handleSave}
-          visible={this.state.isOpen}
-        >
-          <Input
-            value={this.state.name}
-            onChange={this.handleNameChange}
-            onPressEnter={this.handleSave}
-            ref={(input) => { if (input) { this.input = input.refs.input; } }}
-          />
-        </Modal>
-      </MenuItem>
-    );
+    return [
+      <MenuItem key="rename" title="Rename" onClick={this.showModal} />,
+      <Modal
+        key="rename-modal"
+        title="Rename Project"
+        cancelText="Cancel"
+        okText="Save"
+        onCancel={this.handleCancel}
+        onOk={this.handleSave}
+        visible={this.state.isOpen}
+      >
+        <Input
+          value={this.state.name}
+          onChange={this.handleNameChange}
+          onPressEnter={this.handleSave}
+          ref={(input) => { if (input) { this.input = input.input; } }}
+        />
+      </Modal>,
+    ];
   }
 }
 

--- a/rails/client/app/bundles/kaiju/components/common/SelectableList/SelectableList.scss
+++ b/rails/client/app/bundles/kaiju/components/common/SelectableList/SelectableList.scss
@@ -1,4 +1,5 @@
 .kaiju-SelectableList {
   cursor: pointer;
+  margin: 0;
+  padding-left: 0;
 }
-

--- a/rails/client/app/bundles/kaiju/components/common/TreeView/TreeView.scss
+++ b/rails/client/app/bundles/kaiju/components/common/TreeView/TreeView.scss
@@ -1,5 +1,8 @@
 .kaiju-TreeView {
   cursor: default;
+  list-style-type: none;
+  margin: 0;
+  padding-left: 0;
   position: relative;
   user-select: none;
 }
@@ -7,8 +10,6 @@
 .kaiju-TreeView-header {
   align-items: center;
   display: flex;
-  // TODO: This causes layout issues in Firefox, but fixes scrollbars in Chrome
-  // height: 100%;
 }
 
 .kaiju-TreeView-chevron {
@@ -22,6 +23,8 @@
 }
 
 .kaiju-TreeView-children {
+  list-style-type: none;
+  margin: 0;
   padding-left: 20px;
 
   &.is-collapsed {

--- a/rails/client/package-lock.json
+++ b/rails/client/package-lock.json
@@ -108,9 +108,9 @@
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "acorn": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.1.tgz",
-      "integrity": "sha512-D/KGiCpM/VOtTMDS+wfjywEth926WUrArrzYov4N4SI7t+3y8747dPpCmmAvrm/Z3ygqMHnyPxvYYO0yTdn/nQ=="
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+      "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ=="
     },
     "acorn-dynamic-import": {
       "version": "2.0.2",
@@ -135,7 +135,7 @@
       "integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
       "dev": true,
       "requires": {
-        "acorn": "5.5.1"
+        "acorn": "5.5.3"
       }
     },
     "acorn-jsx": {
@@ -210,9 +210,9 @@
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
     },
     "ansi-escapes": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
-      "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
     },
     "ansi-regex": {
       "version": "2.1.1",
@@ -225,49 +225,51 @@
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
     },
     "antd": {
-      "version": "2.13.12",
-      "resolved": "https://registry.npmjs.org/antd/-/antd-2.13.12.tgz",
-      "integrity": "sha512-neGlQXrkmQCvfBWCPuGNnxVVwXi6GrAtRw9/8bWBVQFvfwSz/jkuxn5M+/p4y+fXsR98WR/cwTz8nnWvyotC7g==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/antd/-/antd-3.2.3.tgz",
+      "integrity": "sha512-jwqvebtnjkGeEMqEpCNm6xONJLdTBLOMZW2TT1bpRvUjz7yAqfne/eyEaj26JhQHwso6v2ekZecoB3ySfN2GTw==",
       "requires": {
-        "array-tree-filter": "1.0.1",
+        "array-tree-filter": "2.1.0",
         "babel-runtime": "6.26.0",
         "classnames": "2.2.5",
         "create-react-class": "15.6.3",
         "css-animation": "1.4.1",
         "dom-closest": "0.2.0",
+        "enquire.js": "2.1.6",
         "lodash.debounce": "4.0.8",
+        "lodash.uniqby": "4.7.0",
         "moment": "2.21.0",
         "omit.js": "1.0.0",
         "prop-types": "15.6.1",
         "rc-animate": "2.4.4",
-        "rc-calendar": "9.0.4",
-        "rc-cascader": "0.11.6",
-        "rc-checkbox": "2.0.3",
-        "rc-collapse": "1.7.7",
-        "rc-dialog": "6.5.11",
-        "rc-dropdown": "1.5.1",
-        "rc-editor-mention": "0.6.14",
-        "rc-form": "1.4.8",
-        "rc-input-number": "3.6.10",
-        "rc-menu": "5.0.14",
-        "rc-notification": "2.0.6",
-        "rc-pagination": "1.12.12",
+        "rc-calendar": "9.5.0",
+        "rc-cascader": "0.12.2",
+        "rc-checkbox": "2.1.5",
+        "rc-collapse": "1.8.0",
+        "rc-dialog": "7.1.3",
+        "rc-dropdown": "2.1.1",
+        "rc-editor-mention": "1.1.6",
+        "rc-form": "2.1.7",
+        "rc-input-number": "4.0.2",
+        "rc-menu": "6.2.6",
+        "rc-notification": "3.0.1",
+        "rc-pagination": "1.15.1",
         "rc-progress": "2.2.5",
-        "rc-rate": "2.1.1",
-        "rc-select": "6.9.7",
-        "rc-slider": "8.3.5",
-        "rc-steps": "2.5.2",
-        "rc-switch": "1.5.3",
-        "rc-table": "5.6.13",
-        "rc-tabs": "9.1.11",
-        "rc-time-picker": "2.4.1",
-        "rc-tooltip": "3.4.9",
+        "rc-rate": "2.4.0",
+        "rc-select": "7.7.3",
+        "rc-slider": "8.6.1",
+        "rc-steps": "3.1.0",
+        "rc-switch": "1.6.0",
+        "rc-table": "6.1.6",
+        "rc-tabs": "9.2.4",
+        "rc-time-picker": "3.2.1",
+        "rc-tooltip": "3.7.0",
         "rc-tree": "1.7.11",
-        "rc-tree-select": "1.10.13",
+        "rc-tree-select": "1.12.9",
         "rc-upload": "2.4.4",
         "rc-util": "4.4.0",
         "react-lazy-load": "3.0.13",
-        "react-slick": "0.15.4",
+        "react-slick": "0.17.1",
         "shallowequal": "1.0.2",
         "warning": "3.0.0"
       }
@@ -325,7 +327,7 @@
       "dev": true,
       "requires": {
         "ast-types-flow": "0.0.7",
-        "commander": "2.14.1"
+        "commander": "2.15.0"
       }
     },
     "arr-diff": {
@@ -377,9 +379,9 @@
       "dev": true
     },
     "array-tree-filter": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/array-tree-filter/-/array-tree-filter-1.0.1.tgz",
-      "integrity": "sha1-CorR7v04zoiFhjL5zAQj12NOTV0="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-tree-filter/-/array-tree-filter-2.1.0.tgz",
+      "integrity": "sha512-4ROwICNlNw/Hqa9v+rk5h22KjmzB1JGTMVKP2AKJBOCgb0yL0ASf0+YvCcLNNwquOHNX48jkeZIJ3a+oOQqKcw=="
     },
     "array-union": {
       "version": "1.0.2",
@@ -620,7 +622,7 @@
         "babel-register": "6.26.0",
         "babel-runtime": "6.26.0",
         "chokidar": "1.7.0",
-        "commander": "2.14.1",
+        "commander": "2.15.0",
         "convert-source-map": "1.5.1",
         "fs-readdir-recursive": "1.1.0",
         "glob": "7.1.2",
@@ -630,6 +632,25 @@
         "slash": "1.0.0",
         "source-map": "0.5.7",
         "v8flags": "2.1.1"
+      },
+      "dependencies": {
+        "babel-polyfill": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+          "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.26.0",
+            "core-js": "2.5.3",
+            "regenerator-runtime": "0.10.5"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+          "dev": true
+        }
       }
     },
     "babel-code-frame": {
@@ -833,9 +854,9 @@
       }
     },
     "babel-plugin-import": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/babel-plugin-import/-/babel-plugin-import-1.6.5.tgz",
-      "integrity": "sha512-eV8Cul/A9WaYwY/W8AVVr36fBaygAmxvOv1JBKV6qBal+eseMfkkh4SSTL/WNrRTwkyigIGn8UQOw8eOMqQ6bg==",
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/babel-plugin-import/-/babel-plugin-import-1.6.6.tgz",
+      "integrity": "sha512-Oqtgar2Oyl5JYGJ/7wcF8hVUQEaHwsiOP0uxvzJysjjMOuPgLCvCwEY3/sf92SvgSwaGVKSMhYugVQrbHefBaQ==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "7.0.0-beta.40"
@@ -1166,10 +1187,9 @@
       }
     },
     "babel-polyfill": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
-      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
-      "dev": true,
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.23.0.tgz",
+      "integrity": "sha1-g2TKYt+Or7gwSZ9pkXdGbDsDSZ0=",
       "requires": {
         "babel-runtime": "6.26.0",
         "core-js": "2.5.3",
@@ -1179,8 +1199,7 @@
         "regenerator-runtime": {
           "version": "0.10.5",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
-          "dev": true
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
         }
       }
     },
@@ -1680,13 +1699,6 @@
         "has-ansi": "2.0.0",
         "strip-ansi": "3.0.1",
         "supports-color": "2.0.0"
-      },
-      "dependencies": {
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-        }
       }
     },
     "character-entities": {
@@ -1871,6 +1883,26 @@
         "string-width": "1.0.2",
         "strip-ansi": "3.0.1",
         "wrap-ansi": "2.1.0"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        }
       }
     },
     "clone": {
@@ -1988,9 +2020,9 @@
       }
     },
     "commander": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
-      "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw=="
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.0.tgz",
+      "integrity": "sha512-7B1ilBwtYSbetCgTY1NJFg+gVpestg0fdA1MhC1Vs4ssyfSXnCAjFr+QcQM9/RedXC0EaUx1sG8Smgw2VfgKEg=="
     },
     "common-tags": {
       "version": "1.7.2",
@@ -2112,13 +2144,6 @@
         "os-homedir": "1.0.2",
         "parse-json": "2.2.0",
         "require-from-string": "1.2.1"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-        }
       }
     },
     "create-ecdh": {
@@ -2958,12 +2983,6 @@
           "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
           "dev": true
         },
-        "ansi-escapes": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-          "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
-          "dev": true
-        },
         "cli-cursor": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
@@ -3014,10 +3033,13 @@
           }
         },
         "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
         },
         "onetime": {
           "version": "1.1.0",
@@ -3056,17 +3078,22 @@
             "once": "1.4.0"
           }
         },
-        "rx-lite": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
-          "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
-          "dev": true
-        },
         "slice-ansi": {
           "version": "0.0.4",
           "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
           "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
           "dev": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
         },
         "strip-bom": {
           "version": "3.0.0",
@@ -3092,6 +3119,12 @@
               "version": "3.0.0",
               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
               "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+              "dev": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
               "dev": true
             },
             "string-width": {
@@ -3370,7 +3403,7 @@
       "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
       "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
       "requires": {
-        "acorn": "5.5.1",
+        "acorn": "5.5.3",
         "acorn-jsx": "3.0.1"
       }
     },
@@ -4775,6 +4808,26 @@
         "string-width": "1.0.2",
         "strip-ansi": "3.0.1",
         "wide-align": "1.1.2"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        }
       }
     },
     "gaze": {
@@ -4987,7 +5040,7 @@
       "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
       "requires": {
         "chalk": "1.1.3",
-        "commander": "2.14.1",
+        "commander": "2.15.0",
         "is-my-json-valid": "2.17.2",
         "pinkie-promise": "2.0.1"
       }
@@ -5117,9 +5170,9 @@
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
     },
     "hoist-non-react-statics": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz",
-      "integrity": "sha1-qkSM8JhtVcxAdzsXF0t90GbLfPs="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz",
+      "integrity": "sha512-6Bl6XsDT1ntE0lHbIhr4Kp2PGcleGZ66qu5Jqk8lc0Xc/IeG6gVLmwUGs/K0Us+L8VWoKgj0uWdPMataOsm31w=="
     },
     "home-or-tmp": {
       "version": "2.0.0",
@@ -5131,9 +5184,9 @@
       }
     },
     "hosted-git-info": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
+      "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw=="
     },
     "html-comment-regex": {
       "version": "1.1.1",
@@ -5267,6 +5320,13 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
       "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA=="
     },
+    "image-size": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz",
+      "integrity": "sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w=",
+      "dev": true,
+      "optional": true
+    },
     "immutable": {
       "version": "3.7.6",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz",
@@ -5336,12 +5396,12 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "inquirer": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.0.6.tgz",
+      "integrity": "sha1-4EqqnQW3o8ubD0B9BDdfBEcZA0c=",
       "requires": {
-        "ansi-escapes": "3.0.0",
-        "chalk": "2.3.2",
+        "ansi-escapes": "1.4.0",
+        "chalk": "1.1.3",
         "cli-cursor": "2.1.0",
         "cli-width": "2.2.0",
         "external-editor": "2.1.0",
@@ -5349,71 +5409,10 @@
         "lodash": "4.17.5",
         "mute-stream": "0.0.7",
         "run-async": "2.3.0",
-        "rx-lite": "4.0.8",
-        "rx-lite-aggregates": "4.0.8",
+        "rx": "4.1.0",
         "string-width": "2.1.1",
-        "strip-ansi": "4.0.0",
+        "strip-ansi": "3.0.1",
         "through": "2.3.8"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "requires": {
-            "color-convert": "1.9.1"
-          }
-        },
-        "chalk": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-          "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
-          "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.3.0"
-          }
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "requires": {
-            "ansi-regex": "3.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
-          "requires": {
-            "has-flag": "3.0.0"
-          }
-        }
       }
     },
     "interpret": {
@@ -5616,12 +5615,9 @@
       }
     },
     "is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "requires": {
-        "number-is-nan": "1.0.1"
-      }
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
     },
     "is-generator-fn": {
       "version": "1.0.0",
@@ -5921,6 +5917,17 @@
         "mkdirp": "0.5.1",
         "path-parse": "1.0.5",
         "supports-color": "3.2.3"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "dev": true,
+          "requires": {
+            "has-flag": "1.0.0"
+          }
+        }
       }
     },
     "istanbul-lib-source-maps": {
@@ -5955,6 +5962,12 @@
         "jest-cli": "22.4.2"
       },
       "dependencies": {
+        "ansi-escapes": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
+          "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
+          "dev": true
+        },
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
@@ -6002,12 +6015,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "jest-cli": {
@@ -6061,16 +6068,6 @@
             "execa": "0.7.0",
             "lcid": "1.0.0",
             "mem": "1.1.0"
-          }
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
           }
         },
         "strip-ansi": {
@@ -6635,12 +6632,6 @@
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
         },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
         "os-locale": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
@@ -6650,16 +6641,6 @@
             "execa": "0.7.0",
             "lcid": "1.0.0",
             "mem": "1.1.0"
-          }
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
           }
         },
         "strip-ansi": {
@@ -6940,7 +6921,7 @@
       "dev": true,
       "requires": {
         "abab": "1.0.4",
-        "acorn": "5.5.1",
+        "acorn": "5.5.3",
         "acorn-globals": "4.1.0",
         "array-equal": "1.0.0",
         "browser-process-hrtime": "0.1.2",
@@ -7272,6 +7253,134 @@
       "integrity": "sha1-0wpzxrggHY99jnlWupYWCHpo4O4=",
       "dev": true
     },
+    "less": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/less/-/less-2.7.3.tgz",
+      "integrity": "sha512-KPdIJKWcEAb02TuJtaLrhue0krtRLoRoo7x6BNJIBelO00t/CCdJQUnHW5V34OnHMWzIktSalJxRO+FvytQlCQ==",
+      "dev": true,
+      "requires": {
+        "errno": "0.1.7",
+        "graceful-fs": "4.1.11",
+        "image-size": "0.5.5",
+        "mime": "1.6.0",
+        "mkdirp": "0.5.1",
+        "promise": "7.3.1",
+        "request": "2.81.0",
+        "source-map": "0.5.7"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
+          }
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+          "dev": true,
+          "optional": true
+        },
+        "har-schema": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+          "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
+          "dev": true,
+          "optional": true
+        },
+        "har-validator": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+          "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
+          }
+        },
+        "performance-now": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+          "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
+          "dev": true,
+          "optional": true
+        },
+        "qs": {
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
+          "dev": true,
+          "optional": true
+        },
+        "request": {
+          "version": "2.81.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+          "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.6",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.18",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.1.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.4",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.2.1"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        }
+      }
+    },
+    "less-loader": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/less-loader/-/less-loader-4.0.6.tgz",
+      "integrity": "sha512-WPFY3NMJGJna8kIxtgSu6AVG7K6uRPdfE2J7vpQqFWMN/RkOosV09rOVUt3wghNClWH2Pg7YumD1dHiv1Thfug==",
+      "dev": true,
+      "requires": {
+        "clone": "2.1.1",
+        "loader-utils": "1.1.0",
+        "pify": "3.0.0"
+      },
+      "dependencies": {
+        "clone": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
+          "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
+          "dev": true
+        }
+      }
+    },
     "leven": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
@@ -7337,9 +7446,9 @@
       "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
     },
     "lodash-es": {
-      "version": "4.17.5",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.5.tgz",
-      "integrity": "sha512-Ez3ONp3TK9gX1HYKp6IhetcVybD+2F+Yp6GS9dfH8ue6EOCEzQtQEh4K0FYWBP9qLv+lzeQAYXw+3ySfxyZqkw=="
+      "version": "4.17.7",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.7.tgz",
+      "integrity": "sha512-jzqTi3vk4J5Dxq43cNjB0ekfCjPLHixoY2Sc0WHTo+0r928taLqe/VCt02vY5uQBvg0rdXgL3xWkK4X0MCmZcw=="
     },
     "lodash._getnative": {
       "version": "3.9.1",
@@ -7365,11 +7474,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
-    },
-    "lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
     "lodash.isarguments": {
       "version": "3.1.0",
@@ -7431,6 +7535,11 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
+    },
+    "lodash.uniqby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
+      "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI="
     },
     "log-symbols": {
       "version": "2.2.0",
@@ -7665,13 +7774,6 @@
         "read-pkg-up": "1.0.1",
         "redent": "1.0.0",
         "trim-newlines": "1.0.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-        }
       }
     },
     "merge": {
@@ -7731,6 +7833,13 @@
         "brorand": "1.1.0"
       }
     },
+    "mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true,
+      "optional": true
+    },
     "mime-db": {
       "version": "1.33.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
@@ -7748,6 +7857,16 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+    },
+    "mini-store": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mini-store/-/mini-store-1.0.4.tgz",
+      "integrity": "sha512-AJoqlKcmAFFwZYKem2ACuZKo8ginzsw/yDWiVRoWmv54BIQUomWz0+F+lCaoo2LwQB6YtiQzve9+h/WH4AFXUA==",
+      "requires": {
+        "hoist-non-react-statics": "2.5.0",
+        "prop-types": "15.6.1",
+        "shallowequal": "1.0.2"
+      }
     },
     "minimalistic-assert": {
       "version": "1.0.0",
@@ -7770,9 +7889,9 @@
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "minimist-options": {
       "version": "3.0.2",
@@ -7827,6 +7946,13 @@
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+        }
       }
     },
     "moment": {
@@ -8030,7 +8156,7 @@
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "requires": {
-        "hosted-git-info": "2.5.0",
+        "hosted-git-info": "2.6.0",
         "is-builtin-module": "1.0.0",
         "semver": "5.5.0",
         "validate-npm-package-license": "3.0.3"
@@ -8260,16 +8386,55 @@
         "mimic-fn": "1.2.0"
       }
     },
+    "opencollective": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/opencollective/-/opencollective-1.0.3.tgz",
+      "integrity": "sha1-ruY3K8KBRFg2kMPKja7PwSDdDvE=",
+      "requires": {
+        "babel-polyfill": "6.23.0",
+        "chalk": "1.1.3",
+        "inquirer": "3.0.6",
+        "minimist": "1.2.0",
+        "node-fetch": "1.6.3",
+        "opn": "4.0.2"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "1.6.3",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz",
+          "integrity": "sha1-3CNO3WSJmC1Y6PDbT2lQKavNjAQ=",
+          "requires": {
+            "encoding": "0.1.12",
+            "is-stream": "1.1.0"
+          }
+        }
+      }
+    },
+    "opn": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
+      "integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
+      "requires": {
+        "object-assign": "4.1.1",
+        "pinkie-promise": "2.0.1"
+      }
+    },
     "optimist": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8",
+        "minimist": "0.0.10",
         "wordwrap": "0.0.3"
       },
       "dependencies": {
+        "minimist": {
+          "version": "0.0.10",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+          "dev": true
+        },
         "wordwrap": {
           "version": "0.0.3",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
@@ -8559,6 +8724,16 @@
         "js-base64": "2.4.3",
         "source-map": "0.5.7",
         "supports-color": "3.2.3"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "requires": {
+            "has-flag": "1.0.0"
+          }
+        }
       }
     },
     "postcss-calc": {
@@ -9671,7 +9846,7 @@
             "globals": "11.3.0",
             "ignore": "3.3.7",
             "imurmurhash": "0.1.4",
-            "inquirer": "3.3.0",
+            "inquirer": "3.0.6",
             "is-resolvable": "1.1.0",
             "js-yaml": "3.11.0",
             "json-stable-stringify-without-jsonify": "1.0.1",
@@ -9955,35 +10130,42 @@
       }
     },
     "rc-calendar": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/rc-calendar/-/rc-calendar-9.0.4.tgz",
-      "integrity": "sha512-Ut/QLqkm8QfnomyOduQxb8XEz84Dgrk0H2nmuhWbNNQ5ReoK6ZbFzbyjHAECeIHslL19PxU7aE/8A/MOOCxITw==",
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/rc-calendar/-/rc-calendar-9.5.0.tgz",
+      "integrity": "sha512-L7fcdHy6vdjpSPeW8h2kC4hgWw8czfSIM0SElKDjlAfWwmShTP32yGVEERM/fCL+Zv4o+FuqFJStLrPk/wpoYg==",
       "requires": {
         "babel-runtime": "6.26.0",
         "classnames": "2.2.5",
         "create-react-class": "15.6.3",
         "moment": "2.21.0",
         "prop-types": "15.6.1",
-        "rc-trigger": "1.11.5",
+        "rc-trigger": "2.3.4",
         "rc-util": "4.4.0"
       }
     },
     "rc-cascader": {
-      "version": "0.11.6",
-      "resolved": "https://registry.npmjs.org/rc-cascader/-/rc-cascader-0.11.6.tgz",
-      "integrity": "sha512-j9HXC3HrxBy8vpIE/UKtHCLHRWRd9xj2gIMYOnrvnjehRKFdrHxizIdz4Tx7EuN8cVDZe6GYngxFTtBlWCfBFQ==",
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/rc-cascader/-/rc-cascader-0.12.2.tgz",
+      "integrity": "sha512-Hq9bdEPGwQan65oLfuYojDwY3/PqZYxPFqsd38aYE8/x5shzMrBcA0UVZ9S4ds9g+T604cwAEIDJFYEePtGK3Q==",
       "requires": {
         "array-tree-filter": "1.0.1",
         "prop-types": "15.6.1",
-        "rc-trigger": "1.11.5",
+        "rc-trigger": "2.3.4",
         "rc-util": "4.4.0",
         "shallow-equal": "1.0.0"
+      },
+      "dependencies": {
+        "array-tree-filter": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/array-tree-filter/-/array-tree-filter-1.0.1.tgz",
+          "integrity": "sha1-CorR7v04zoiFhjL5zAQj12NOTV0="
+        }
       }
     },
     "rc-checkbox": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/rc-checkbox/-/rc-checkbox-2.0.3.tgz",
-      "integrity": "sha1-Q2qdUIlI4iSYDwU16nOLSBd6jyU=",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/rc-checkbox/-/rc-checkbox-2.1.5.tgz",
+      "integrity": "sha512-WXKnZV6ipS3Jsmd7mVenVUQf+ictgWZW0RqiH+7MeYdzGj/SL4g/S6MZgRdgzaBS2tGBCp4bvhGcyZLns6uQxw==",
       "requires": {
         "babel-runtime": "6.26.0",
         "classnames": "2.2.5",
@@ -9992,9 +10174,9 @@
       }
     },
     "rc-collapse": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/rc-collapse/-/rc-collapse-1.7.7.tgz",
-      "integrity": "sha512-F9eWCcFtwb/H7ot1e/Z9CamVM1bQ0GaTx3Agkle6LrhrcPxuWTH00dldmtk0HelCBK43TyhTWoHEFB5S4biPLA==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/rc-collapse/-/rc-collapse-1.8.0.tgz",
+      "integrity": "sha512-X5rWiZ6edMe1K/pnnniGzZirdBJIS7fIElIEnCStmHtD5Bj5F512KLX+YGjTrcUb9pgmdSUrBBaKhUzeMDOS2w==",
       "requires": {
         "classnames": "2.2.5",
         "css-animation": "1.4.1",
@@ -10003,31 +10185,32 @@
       }
     },
     "rc-dialog": {
-      "version": "6.5.11",
-      "resolved": "https://registry.npmjs.org/rc-dialog/-/rc-dialog-6.5.11.tgz",
-      "integrity": "sha512-FGifsGYvCO8vZQ6SBezXUf60JZ2wa2tHv+qLnUPA7HJaR52v4l4pVwQJgdbNiE3lvveH0Qq4x6C9ZQjTAK5SVA==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/rc-dialog/-/rc-dialog-7.1.3.tgz",
+      "integrity": "sha512-c7h3zGU2li//faIaM+QEqbCevGi3qyDcXHyiSAzxMdDObLpm39fpivMhBvvWYRw8dD8f68x09VALTJhbqotcKg==",
       "requires": {
         "babel-runtime": "6.26.0",
-        "create-react-class": "15.6.3",
-        "object-assign": "4.1.1",
         "rc-animate": "2.4.4",
         "rc-util": "4.4.0"
       }
     },
     "rc-dropdown": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/rc-dropdown/-/rc-dropdown-1.5.1.tgz",
-      "integrity": "sha512-nq+9ZShevzvJXOQyYaACQKlMYWUqnzJCh+TEEy1qpsj5lYeTd9FqFnG6mn2PiL/BeWBWW/lbjaHn56o5e9GJ8Q==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/rc-dropdown/-/rc-dropdown-2.1.1.tgz",
+      "integrity": "sha512-KlflmCHVl273zNj56nLgSZmA5kFbTf7cOzGoF1Nfaj5RpKzgBEHHwXZ9UNDUxdrFW7znJQSLBUo3cNEkqN6J5w==",
       "requires": {
+        "babel-runtime": "6.26.0",
         "prop-types": "15.6.1",
-        "rc-trigger": "1.11.5"
+        "rc-trigger": "2.3.4"
       }
     },
     "rc-editor-core": {
-      "version": "0.7.9",
-      "resolved": "https://registry.npmjs.org/rc-editor-core/-/rc-editor-core-0.7.9.tgz",
-      "integrity": "sha1-3+j6IPM66kG8rBykhJNLYA27dm0=",
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/rc-editor-core/-/rc-editor-core-0.8.6.tgz",
+      "integrity": "sha512-6M4C0qLTf/UvQA0XNb8BWlb5+tZ5LCZKc9Hs0oH6Fn+18XMRILYiUKBCdLObaj0LVeq5vhq+zra9sjfqBEguHQ==",
       "requires": {
+        "babel-runtime": "6.26.0",
+        "classnames": "2.2.5",
         "draft-js": "0.10.5",
         "immutable": "3.7.6",
         "lodash": "4.17.5",
@@ -10036,29 +10219,29 @@
       }
     },
     "rc-editor-mention": {
-      "version": "0.6.14",
-      "resolved": "https://registry.npmjs.org/rc-editor-mention/-/rc-editor-mention-0.6.14.tgz",
-      "integrity": "sha512-2fhxptmTLoWF0qs3pz+6Dh40xi0mKuUCFxo17sKi9x1OpAnp1JGB27dc9iV1oP1l8dJCLRKMtInTMGbCX18OzA==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/rc-editor-mention/-/rc-editor-mention-1.1.6.tgz",
+      "integrity": "sha512-fzD0HueQrp8CYe6HO44pyD1p1kNk0fJvxG0VpZ67fSSDz8AiMS2L6nduw7XNJ+vG64YsGQW4rqACb1Lc7+SYLA==",
       "requires": {
+        "babel-runtime": "6.26.0",
         "classnames": "2.2.5",
         "dom-scroll-into-view": "1.2.1",
         "draft-js": "0.10.5",
-        "immutable": "3.7.6",
         "prop-types": "15.6.1",
         "rc-animate": "2.4.4",
-        "rc-editor-core": "0.7.9"
+        "rc-editor-core": "0.8.6"
       }
     },
     "rc-form": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/rc-form/-/rc-form-1.4.8.tgz",
-      "integrity": "sha512-OISgu4LdHmLg/RvnbVmQoRoP2nbthge+bZ6/IKqPm4j4P2s5wQJTSuAKLR4kJoJla0V69czwd7MsOwQN45eBaA==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/rc-form/-/rc-form-2.1.7.tgz",
+      "integrity": "sha512-Sz6gnkjD92sM7E/QTSFkgiyiYEzZ3hAmKxgPJY2l3PK9DKGHEamJq5Lj5L4bJWW3pLGzkEZJOC6xS5+6nde/yA==",
       "requires": {
         "async-validator": "1.8.2",
         "babel-runtime": "6.26.0",
         "create-react-class": "15.6.3",
         "dom-scroll-into-view": "1.2.1",
-        "hoist-non-react-statics": "1.2.0",
+        "hoist-non-react-statics": "2.5.0",
         "lodash": "4.17.5",
         "warning": "3.0.0"
       }
@@ -10074,21 +10257,20 @@
       }
     },
     "rc-input-number": {
-      "version": "3.6.10",
-      "resolved": "https://registry.npmjs.org/rc-input-number/-/rc-input-number-3.6.10.tgz",
-      "integrity": "sha512-IlZBLfSzGQTFE6CgYDid8gthSWlC015JsNpfHdTmhDgGbagmBNijJD9rS+SMcDCADyz5VpIlPg2ZCzsg6C07HQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/rc-input-number/-/rc-input-number-4.0.2.tgz",
+      "integrity": "sha512-rQa0/SaSISVduY5jBRkYfStXEVogdATL3AHj21lzfKTt1+pj3hW+A68oml/0x2MMCia6JWr5xbaps2TpH0eS/Q==",
       "requires": {
         "babel-runtime": "6.26.0",
         "classnames": "2.2.5",
-        "create-react-class": "15.6.3",
         "prop-types": "15.6.1",
-        "rc-touchable": "1.2.3"
+        "rmc-feedback": "1.0.4"
       }
     },
     "rc-menu": {
-      "version": "5.0.14",
-      "resolved": "https://registry.npmjs.org/rc-menu/-/rc-menu-5.0.14.tgz",
-      "integrity": "sha512-Ks6GOB9obVvrHCtbp5X8xCK+D08Hwlrjkx60sa4RYPuimuUS4uQo8yV1FJLPTvRCx1PXxM8Clj23jawuoPDs3g==",
+      "version": "6.2.6",
+      "resolved": "https://registry.npmjs.org/rc-menu/-/rc-menu-6.2.6.tgz",
+      "integrity": "sha512-K4fJ/ywxO20TqLsbnDFbDU7Ng8vI/VQgNdGZi5yfY2fk5dInT7bgTZIHXzGgnGrGxb9Tu1+vHl3dcsFYnAo26A==",
       "requires": {
         "babel-runtime": "6.26.0",
         "classnames": "2.2.5",
@@ -10096,13 +10278,14 @@
         "dom-scroll-into-view": "1.2.1",
         "prop-types": "15.6.1",
         "rc-animate": "2.4.4",
+        "rc-trigger": "2.3.4",
         "rc-util": "4.4.0"
       }
     },
     "rc-notification": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/rc-notification/-/rc-notification-2.0.6.tgz",
-      "integrity": "sha512-KD5JcCIiZQaTvbGsbevRFQbHcxTkj49A5ceCBQ2RAnLbCaC9H+plXTZJEUUDMDmESVVx7491CvTzWVAvR9z/Pw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/rc-notification/-/rc-notification-3.0.1.tgz",
+      "integrity": "sha512-DvnTJKh4V8i8JWe448Nymrb0D+r98Rg8sSdeZbZJJ+juHZUV8uWWAEZwQRemC0I+4J/xNQTBpEFcPgvd+darHg==",
       "requires": {
         "babel-runtime": "6.26.0",
         "classnames": "2.2.5",
@@ -10112,9 +10295,9 @@
       }
     },
     "rc-pagination": {
-      "version": "1.12.12",
-      "resolved": "https://registry.npmjs.org/rc-pagination/-/rc-pagination-1.12.12.tgz",
-      "integrity": "sha512-q3JfDfQjIem+88ELFqt3beoee4UQep8PZOdCkkMIlebEuMZMPXKOaChcmCyii0qkn3akoVfIChUjVOCCHtXhnw==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/rc-pagination/-/rc-pagination-1.15.1.tgz",
+      "integrity": "sha512-FZ9XE6rnCj8IUEVr/YcZfq1rqzVKfNO8pYVsxXBDq23C2WHv3sC8nrwe+LwrlMLf57UdpVjShUVGGMH9f+4b6A==",
       "requires": {
         "babel-runtime": "6.26.0",
         "prop-types": "15.6.1"
@@ -10130,18 +10313,20 @@
       }
     },
     "rc-rate": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/rc-rate/-/rc-rate-2.1.1.tgz",
-      "integrity": "sha1-iK7aiz1kcLuuT2UYxlKgKpWb3cU=",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/rc-rate/-/rc-rate-2.4.0.tgz",
+      "integrity": "sha512-gYHxaXqObiIw1ekRS8tq2YUKpTGL/Q9LxMdSCXZS++d5bVsmmTCZUvJFKEt0IfLb19sZtxCaQvwanzNpqaxY7Q==",
       "requires": {
+        "babel-runtime": "6.26.0",
         "classnames": "2.2.5",
-        "prop-types": "15.6.1"
+        "prop-types": "15.6.1",
+        "rc-util": "4.4.0"
       }
     },
     "rc-select": {
-      "version": "6.9.7",
-      "resolved": "https://registry.npmjs.org/rc-select/-/rc-select-6.9.7.tgz",
-      "integrity": "sha512-g4xNsDk5usOOyt9KJKOjF/HIM4q9Oij4vfBZ+siwoqxbP7P20+XoAUD7AKaV0Hd7rvmnM3q/4qdKQfty9Ojnmg==",
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/rc-select/-/rc-select-7.7.3.tgz",
+      "integrity": "sha512-d4BnvaBzN02JftKl6p01wld9hIQF2r+iL/6hVyKGxgmjB1vWucoaJsJQFZ+row2Jenjln2ujhTY1c4wT9XmMsw==",
       "requires": {
         "babel-runtime": "6.26.0",
         "classnames": "2.2.5",
@@ -10149,40 +10334,41 @@
         "dom-scroll-into-view": "1.2.1",
         "prop-types": "15.6.1",
         "rc-animate": "2.4.4",
-        "rc-menu": "5.0.14",
-        "rc-trigger": "1.11.5",
+        "rc-menu": "6.2.6",
+        "rc-trigger": "2.3.4",
         "rc-util": "4.4.0",
         "warning": "3.0.0"
       }
     },
     "rc-slider": {
-      "version": "8.3.5",
-      "resolved": "https://registry.npmjs.org/rc-slider/-/rc-slider-8.3.5.tgz",
-      "integrity": "sha512-zg2fa8WOH101eMCsTShUKFPJ/t74B0m1gE4Icb+gjQ//viX/HrWdF03yiSaXHrgIyXu7go0+uaKgVFXv4r/jHA==",
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/rc-slider/-/rc-slider-8.6.1.tgz",
+      "integrity": "sha512-6DoLW5pWR8K/7Z55E5wKZGGa22HFY6LB4Z0PegzSXrQ/RqUHm9hFHRA3FYCuPOsg/Zsi+SgGPvzC2P/I/YZ6Lg==",
       "requires": {
         "babel-runtime": "6.26.0",
         "classnames": "2.2.5",
         "prop-types": "15.6.1",
-        "rc-tooltip": "3.4.9",
+        "rc-tooltip": "3.7.0",
         "rc-util": "4.4.0",
         "shallowequal": "1.0.2",
         "warning": "3.0.0"
       }
     },
     "rc-steps": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/rc-steps/-/rc-steps-2.5.2.tgz",
-      "integrity": "sha512-FsKpogxMaF2GYX3G9pn0pwTm9XTS+fAge/7F9uN0sDRPULUODBaUtlVUAOrDXIFOcIxxeku2UWBA6WfUvmcfTw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/rc-steps/-/rc-steps-3.1.0.tgz",
+      "integrity": "sha512-MT9fiBs1YhJ+ndxSNLzbCNYi+n0IXXl1F1la5ewXpkUYeOaHWBYwP1wTCtUHWJ7ovJ7I2i03XXHzfU1d2zMN/g==",
       "requires": {
+        "babel-runtime": "6.26.0",
         "classnames": "2.2.5",
         "lodash.debounce": "4.0.8",
         "prop-types": "15.6.1"
       }
     },
     "rc-switch": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/rc-switch/-/rc-switch-1.5.3.tgz",
-      "integrity": "sha512-mOs6ZRgtioWt34CBrxC0nH5vJcg8cJ6RuDExN7qua3m9WYmd6NoSMgK3hXI7VDXuAsSLUGiE9MhJyIeeGcr57A==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/rc-switch/-/rc-switch-1.6.0.tgz",
+      "integrity": "sha512-tlnYj92N/PxFLWJObATgSPYWESCFTUtdFjDRbCJFvSd4j2a8IFLz20X/5d3OTnFtf7DcxLTa/aGIPmsI3mFn3g==",
       "requires": {
         "babel-runtime": "6.26.0",
         "classnames": "2.2.5",
@@ -10190,38 +10376,29 @@
       }
     },
     "rc-table": {
-      "version": "5.6.13",
-      "resolved": "https://registry.npmjs.org/rc-table/-/rc-table-5.6.13.tgz",
-      "integrity": "sha512-gyhtFKXgj1TlWzJ2eA5nFWsjXuqb0bSZP8pyjXbXOoCvWSHRRf8CAJK9sF+8x9JJjXDVNSqsZtj+GvDpW4B4MA==",
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/rc-table/-/rc-table-6.1.6.tgz",
+      "integrity": "sha512-xE5S4Ez5RmvmnNquzJFq9nHPtA00FVS/UJQDreqaZ/3FU91XRc/8qgQykYXfYML+JnvpCsU18wEEoXUd1XIVBw==",
       "requires": {
         "babel-runtime": "6.26.0",
         "component-classes": "1.2.6",
-        "lodash.get": "4.4.2",
+        "lodash": "4.17.5",
+        "mini-store": "1.0.4",
         "prop-types": "15.6.1",
         "rc-util": "4.4.0",
-        "shallowequal": "0.2.2",
+        "shallowequal": "1.0.2",
         "warning": "3.0.0"
-      },
-      "dependencies": {
-        "shallowequal": {
-          "version": "0.2.2",
-          "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-0.2.2.tgz",
-          "integrity": "sha1-HjL9W8q2rWiKSBLLDMBO/HXHAU4=",
-          "requires": {
-            "lodash.keys": "3.1.2"
-          }
-        }
       }
     },
     "rc-tabs": {
-      "version": "9.1.11",
-      "resolved": "https://registry.npmjs.org/rc-tabs/-/rc-tabs-9.1.11.tgz",
-      "integrity": "sha512-pepWb6YYqvskWyXxc2klJR6GH4//4rSEFAttIJaRuZn++uSf3k5nOSPvO0x0qGOoX+Dz8P8DIcnoZQADvYcr7g==",
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/rc-tabs/-/rc-tabs-9.2.4.tgz",
+      "integrity": "sha512-sibLucs7d4RzZ83EO9YlMSw9TIWsa/DFC4uc8iyNiPo5V/u6zLJXZTOAWSY9deASUCkDYJ9JtydUN9npLnVXGQ==",
       "requires": {
         "babel-runtime": "6.26.0",
         "classnames": "2.2.5",
         "create-react-class": "15.6.3",
-        "lodash.debounce": "4.0.8",
+        "lodash": "4.17.5",
         "prop-types": "15.6.1",
         "rc-hammerjs": "0.6.9",
         "rc-util": "4.4.0",
@@ -10229,33 +10406,25 @@
       }
     },
     "rc-time-picker": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/rc-time-picker/-/rc-time-picker-2.4.1.tgz",
-      "integrity": "sha1-B049EgjogO2w2Zp7nMFbk1BdqMY=",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/rc-time-picker/-/rc-time-picker-3.2.1.tgz",
+      "integrity": "sha512-aULPDcaqc/p5Rxcfp4sTl/Igxw5Ej5+mSdEkIqTo9SbWULQ0QaH9wGZ13niTHOx50RLklJzvOIptXZi3LXXQNA==",
       "requires": {
         "babel-runtime": "6.26.0",
         "classnames": "2.2.5",
         "moment": "2.21.0",
         "prop-types": "15.6.1",
-        "rc-trigger": "1.11.5"
+        "rc-trigger": "2.3.4"
       }
     },
     "rc-tooltip": {
-      "version": "3.4.9",
-      "resolved": "https://registry.npmjs.org/rc-tooltip/-/rc-tooltip-3.4.9.tgz",
-      "integrity": "sha512-D9VFsy+0sB6s3zZ/DSTI+AJB106mOrRVTw3IXwF1mMhjHaCvEO+CGzHcTfyj9k6tY+5c4E+fd+r2g4DnkjgSNg==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/rc-tooltip/-/rc-tooltip-3.7.0.tgz",
+      "integrity": "sha512-xEoUMatXp8OEL61UFH0+NrC39nkKzpOBhLrJCnnRpDRduU8L3DOhF6CNlIMkvg68hxlGGdquFtFw2t+1xNLX5A==",
       "requires": {
         "babel-runtime": "6.26.0",
         "prop-types": "15.6.1",
-        "rc-trigger": "1.11.5"
-      }
-    },
-    "rc-touchable": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/rc-touchable/-/rc-touchable-1.2.3.tgz",
-      "integrity": "sha1-X0mDJOPQubpgGpxINJWOqixxNhg=",
-      "requires": {
-        "babel-runtime": "6.26.0"
+        "rc-trigger": "2.3.4"
       }
     },
     "rc-tree": {
@@ -10272,9 +10441,9 @@
       }
     },
     "rc-tree-select": {
-      "version": "1.10.13",
-      "resolved": "https://registry.npmjs.org/rc-tree-select/-/rc-tree-select-1.10.13.tgz",
-      "integrity": "sha512-OqyuN3WvizIaH0aa07FBK0BPWQOqm67A2Xv1gzqsHIXaLAs5yO1EEtx3UncfCDLyk6Uk/h580pepNp4Cby/i5Q==",
+      "version": "1.12.9",
+      "resolved": "https://registry.npmjs.org/rc-tree-select/-/rc-tree-select-1.12.9.tgz",
+      "integrity": "sha512-8QAVR0QOIZMuY7wdE/esLPElF9km6zQn2XP4QaYwiQZWdNluLS2jZiKgIujVE3aOkKhWrxTLRkaQfQu07Ukd9A==",
       "requires": {
         "babel-runtime": "6.26.0",
         "classnames": "2.2.5",
@@ -10282,17 +10451,16 @@
         "prop-types": "15.6.1",
         "rc-animate": "2.4.4",
         "rc-tree": "1.7.11",
-        "rc-trigger": "1.11.5",
+        "rc-trigger": "2.3.4",
         "rc-util": "4.4.0"
       }
     },
     "rc-trigger": {
-      "version": "1.11.5",
-      "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-1.11.5.tgz",
-      "integrity": "sha512-MBuUPw1nFzA4K7jQOwb7uvFaZFjXGd00EofUYiZ+l/fgKVq8wnLC0lkv36kwqM7vfKyftRo2sh7cWVpdPuNnnw==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-2.3.4.tgz",
+      "integrity": "sha512-xPhda3SfGWHywEbVJu2VxpWg99ELStzNPcdnxb7lZ9XwUnHjUeX9KCaIbJa9GUuoVHx3mQP1s2m3ttIB8aashQ==",
       "requires": {
         "babel-runtime": "6.26.0",
-        "create-react-class": "15.6.3",
         "prop-types": "15.6.1",
         "rc-align": "2.3.5",
         "rc-animate": "2.4.4",
@@ -10468,22 +10636,15 @@
         "hoist-non-react-statics": "2.5.0",
         "invariant": "2.2.3",
         "lodash": "4.17.5",
-        "lodash-es": "4.17.5",
+        "lodash-es": "4.17.7",
         "loose-envify": "1.3.1",
         "prop-types": "15.6.1"
-      },
-      "dependencies": {
-        "hoist-non-react-statics": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz",
-          "integrity": "sha512-6Bl6XsDT1ntE0lHbIhr4Kp2PGcleGZ66qu5Jqk8lc0Xc/IeG6gVLmwUGs/K0Us+L8VWoKgj0uWdPMataOsm31w=="
-        }
       }
     },
     "react-slick": {
-      "version": "0.15.4",
-      "resolved": "https://registry.npmjs.org/react-slick/-/react-slick-0.15.4.tgz",
-      "integrity": "sha512-RXKA8V6NmpTz6Ngo3XB5dg4GrGwDln89j5uG9Z4NXOedlVCzfG3LcHBVC5Pqs411Arbcp8nlzcg39g+rT6OPHw==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/react-slick/-/react-slick-0.17.1.tgz",
+      "integrity": "sha512-ffrbR8bSefalLCsaynPouS11cp+AO99aUxQiUYTKSJIY7fkqqSfYq/2bJMW3D1p6ejQdpzf9sQHIbgG9xbzNhg==",
       "requires": {
         "can-use-dom": "0.1.0",
         "classnames": "2.2.5",
@@ -10491,7 +10652,7 @@
         "enquire.js": "2.1.6",
         "json2mq": "0.2.0",
         "object-assign": "4.1.1",
-        "slick-carousel": "1.8.1"
+        "opencollective": "1.0.3"
       }
     },
     "react-transition-group": {
@@ -10581,6 +10742,15 @@
         "mute-stream": "0.0.5"
       },
       "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
         "mute-stream": {
           "version": "0.0.5",
           "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
@@ -10654,7 +10824,7 @@
       "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
       "requires": {
         "lodash": "4.17.5",
-        "lodash-es": "4.17.5",
+        "lodash-es": "4.17.7",
         "loose-envify": "1.3.1",
         "symbol-observable": "1.2.0"
       }
@@ -10997,6 +11167,15 @@
         "inherits": "2.0.3"
       }
     },
+    "rmc-feedback": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/rmc-feedback/-/rmc-feedback-1.0.4.tgz",
+      "integrity": "sha512-cRrywsfsQlw92Uz7qKzBxtyO1w0GWcP5yy/S8sec/6mIUdCn86olQuhBMHxpIpHGcEIJ+J9lBjl3DOrBD0Plrw==",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "classnames": "2.2.5"
+      }
+    },
     "run-async": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
@@ -11005,18 +11184,16 @@
         "is-promise": "2.1.0"
       }
     },
-    "rx-lite": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ="
+    "rx": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
+      "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I="
     },
-    "rx-lite-aggregates": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
-      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
-      "requires": {
-        "rx-lite": "4.0.8"
-      }
+    "rx-lite": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
+      "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
+      "dev": true
     },
     "safe-buffer": {
       "version": "5.1.1",
@@ -11046,14 +11223,6 @@
         "minimist": "1.2.0",
         "walker": "1.0.7",
         "watch": "0.18.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        }
       }
     },
     "sass-graph": {
@@ -11248,19 +11417,7 @@
       "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
       "requires": {
         "is-fullwidth-code-point": "2.0.0"
-      },
-      "dependencies": {
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-        }
       }
-    },
-    "slick-carousel": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/slick-carousel/-/slick-carousel-1.8.1.tgz",
-      "integrity": "sha512-XB9Ftrf2EEKfzoQXt3Nitrt/IPbT+f1fgqBdoxO3W/+JYvtEOW6EgxnWfr9GH6nmULv7Y2tPmEX3koxThVmebA=="
     },
     "snapdragon": {
       "version": "0.8.1",
@@ -11694,13 +11851,27 @@
       }
     },
     "string-width": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "strip-ansi": "3.0.1"
+        "is-fullwidth-code-point": "2.0.0",
+        "strip-ansi": "4.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        }
       }
     },
     "string_decoder": {
@@ -11824,12 +11995,6 @@
         "table": "4.0.2"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
         "ansi-styles": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -11917,12 +12082,6 @@
           "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
           "dev": true
         },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
         "js-yaml": {
           "version": "3.11.0",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
@@ -11979,12 +12138,6 @@
             "redent": "2.0.0",
             "trim-newlines": "2.0.0"
           }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
         },
         "parse-json": {
           "version": "3.0.0",
@@ -12074,25 +12227,6 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "3.0.0"
-          }
         },
         "strip-bom": {
           "version": "3.0.0",
@@ -12289,12 +12423,9 @@
       }
     },
     "supports-color": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-      "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-      "requires": {
-        "has-flag": "1.0.0"
-      }
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
     },
     "svg-tags": {
       "version": "1.0.0",
@@ -12345,11 +12476,6 @@
         "string-width": "2.1.1"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-        },
         "ansi-styles": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -12372,28 +12498,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "requires": {
-            "ansi-regex": "3.0.0"
-          }
         },
         "supports-color": {
           "version": "5.3.0",
@@ -12442,18 +12546,6 @@
         "classnames": "2.2.5",
         "prop-types": "15.6.1",
         "terra-base": "3.2.0"
-      }
-    },
-    "terra-avatar": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/terra-avatar/-/terra-avatar-1.0.0.tgz",
-      "integrity": "sha512-JSKeeppOxIBc8Rb35tnavUZDJh+jFsDAluu9esQPsBM5W4kc21fBM8lPLzRJLsv6qT+IGRow/XPCVvI55A6ZhQ==",
-      "requires": {
-        "classnames": "2.2.5",
-        "prop-types": "15.6.1",
-        "terra-base": "3.2.0",
-        "terra-image": "2.2.0",
-        "terra-mixins": "1.13.0"
       }
     },
     "terra-badge": {
@@ -12805,16 +12897,6 @@
         "terra-icon": "2.2.0"
       }
     },
-    "terra-form-input": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/terra-form-input/-/terra-form-input-1.1.0.tgz",
-      "integrity": "sha512-W2zKQYhfQNeqZZaICqjZJfga9HYy2eBDF1rM9gWnHvNf/FrbEuWF0C7Mtqd/d78h2y7rXO0+X7qNsB0UD1XFow==",
-      "requires": {
-        "classnames": "2.2.5",
-        "prop-types": "15.6.1",
-        "terra-base": "3.2.0"
-      }
-    },
     "terra-form-radio": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/terra-form-radio/-/terra-form-radio-2.2.0.tgz",
@@ -12918,9 +13000,9 @@
       }
     },
     "terra-kaiju-plugin": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/terra-kaiju-plugin/-/terra-kaiju-plugin-0.9.0.tgz",
-      "integrity": "sha512-yy9LefKRP/UDx8OrHjv+11SPqTBPXgye9JsKy55D6ySA5THluwh99mrCBLVg0BSPqgRjFm8at1pNR33+lcwDSQ==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/terra-kaiju-plugin/-/terra-kaiju-plugin-0.8.0.tgz",
+      "integrity": "sha512-xqXJuX9Iy9eKnP7vdeSNV2HF7L8SENfn11MH7aENbkDuhuegP5YSia+nKidjT8+rRIYmgEbAqUi7gEe7PFMLQg==",
       "requires": {
         "app-root-path": "2.0.1",
         "autoprefixer": "6.7.7",
@@ -12941,7 +13023,6 @@
         "style-loader": "0.13.2",
         "terra-alert": "2.2.0",
         "terra-arrange": "2.2.0",
-        "terra-avatar": "1.0.0",
         "terra-badge": "2.2.0",
         "terra-base": "3.2.0",
         "terra-button": "2.2.0",
@@ -12965,7 +13046,6 @@
         "terra-form": "2.2.0",
         "terra-form-checkbox": "2.2.0",
         "terra-form-field": "2.2.0",
-        "terra-form-input": "1.1.0",
         "terra-form-radio": "2.2.0",
         "terra-form-select": "2.2.0",
         "terra-form-textarea": "2.2.0",
@@ -14069,14 +14149,6 @@
       "requires": {
         "exec-sh": "0.2.1",
         "minimist": "1.2.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        }
       }
     },
     "watchpack": {
@@ -14423,7 +14495,7 @@
       "integrity": "sha512-3kOFejWqj5ISpJk4Qj/V7w98h9Vl52wak3CLiw/cDOfbVTq7FeoZ0SdoHHY9PYlHr50ZS42OfvzE2vB4nncKQg==",
       "dev": true,
       "requires": {
-        "acorn": "5.5.1",
+        "acorn": "5.5.3",
         "acorn-dynamic-import": "2.0.2",
         "ajv": "6.2.1",
         "ajv-keywords": "3.1.0",
@@ -14464,12 +14536,6 @@
           "integrity": "sha1-rCsnk5xUPpXSwG5/f1wnvkqlQ74=",
           "dev": true
         },
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
         "camelcase": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
@@ -14480,12 +14546,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
           "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "load-json-file": {
@@ -14545,25 +14605,6 @@
           "requires": {
             "find-up": "2.1.0",
             "read-pkg": "2.0.0"
-          }
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "3.0.0"
           }
         },
         "strip-bom": {
@@ -14696,6 +14737,26 @@
       "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
       "requires": {
         "string-width": "1.0.2"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        }
       }
     },
     "window-size": {
@@ -14716,6 +14777,26 @@
       "requires": {
         "string-width": "1.0.2",
         "strip-ansi": "3.0.1"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        }
       }
     },
     "wrappy": {
@@ -14809,6 +14890,24 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
           "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
         }
       }
     },

--- a/rails/client/package-lock.json
+++ b/rails/client/package-lock.json
@@ -2197,7 +2197,7 @@
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
       "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
       "requires": {
-        "lru-cache": "4.1.1",
+        "lru-cache": "4.1.2",
         "which": "1.3.0"
       }
     },
@@ -3499,7 +3499,7 @@
           "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
           "dev": true,
           "requires": {
-            "lru-cache": "4.1.1",
+            "lru-cache": "4.1.2",
             "shebang-command": "1.2.0",
             "which": "1.3.0"
           }
@@ -7631,9 +7631,9 @@
       }
     },
     "lru-cache": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
+      "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
       "requires": {
         "pseudomap": "1.0.2",
         "yallist": "2.1.2"
@@ -9818,7 +9818,7 @@
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
           "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
           "requires": {
-            "lru-cache": "4.1.1",
+            "lru-cache": "4.1.2",
             "shebang-command": "1.2.0",
             "which": "1.3.0"
           }
@@ -12548,6 +12548,18 @@
         "terra-base": "3.2.0"
       }
     },
+    "terra-avatar": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/terra-avatar/-/terra-avatar-1.0.0.tgz",
+      "integrity": "sha512-JSKeeppOxIBc8Rb35tnavUZDJh+jFsDAluu9esQPsBM5W4kc21fBM8lPLzRJLsv6qT+IGRow/XPCVvI55A6ZhQ==",
+      "requires": {
+        "classnames": "2.2.5",
+        "prop-types": "15.6.1",
+        "terra-base": "3.2.0",
+        "terra-image": "2.2.0",
+        "terra-mixins": "1.13.0"
+      }
+    },
     "terra-badge": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/terra-badge/-/terra-badge-2.2.0.tgz",
@@ -12897,6 +12909,16 @@
         "terra-icon": "2.2.0"
       }
     },
+    "terra-form-input": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/terra-form-input/-/terra-form-input-1.1.0.tgz",
+      "integrity": "sha512-W2zKQYhfQNeqZZaICqjZJfga9HYy2eBDF1rM9gWnHvNf/FrbEuWF0C7Mtqd/d78h2y7rXO0+X7qNsB0UD1XFow==",
+      "requires": {
+        "classnames": "2.2.5",
+        "prop-types": "15.6.1",
+        "terra-base": "3.2.0"
+      }
+    },
     "terra-form-radio": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/terra-form-radio/-/terra-form-radio-2.2.0.tgz",
@@ -13000,9 +13022,9 @@
       }
     },
     "terra-kaiju-plugin": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/terra-kaiju-plugin/-/terra-kaiju-plugin-0.8.0.tgz",
-      "integrity": "sha512-xqXJuX9Iy9eKnP7vdeSNV2HF7L8SENfn11MH7aENbkDuhuegP5YSia+nKidjT8+rRIYmgEbAqUi7gEe7PFMLQg==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/terra-kaiju-plugin/-/terra-kaiju-plugin-0.9.0.tgz",
+      "integrity": "sha512-yy9LefKRP/UDx8OrHjv+11SPqTBPXgye9JsKy55D6ySA5THluwh99mrCBLVg0BSPqgRjFm8at1pNR33+lcwDSQ==",
       "requires": {
         "app-root-path": "2.0.1",
         "autoprefixer": "6.7.7",
@@ -13023,6 +13045,7 @@
         "style-loader": "0.13.2",
         "terra-alert": "2.2.0",
         "terra-arrange": "2.2.0",
+        "terra-avatar": "1.0.0",
         "terra-badge": "2.2.0",
         "terra-base": "3.2.0",
         "terra-button": "2.2.0",
@@ -13046,6 +13069,7 @@
         "terra-form": "2.2.0",
         "terra-form-checkbox": "2.2.0",
         "terra-form-field": "2.2.0",
+        "terra-form-input": "1.1.0",
         "terra-form-radio": "2.2.0",
         "terra-form-select": "2.2.0",
         "terra-form-textarea": "2.2.0",

--- a/rails/client/package.json
+++ b/rails/client/package.json
@@ -17,7 +17,7 @@
     "client/node_modules"
   ],
   "dependencies": {
-    "antd": "^2.7.4",
+    "antd": "^3.2.3",
     "axios": "^0.17.1",
     "classnames": "^2.2.5",
     "github-markdown-css": "^2.10.0",
@@ -25,8 +25,8 @@
     "marked": "^0.3.9",
     "mousetrap": "^1.6.1",
     "prop-types": "^15.5.10",
-    "react-addons-css-transition-group": "^15.4.2",
     "react": "^16.0.0",
+    "react-addons-css-transition-group": "^15.4.2",
     "react-copy-to-clipboard": "^5.0.0",
     "react-dom": "^16.0.0",
     "react-on-rails": "^10.0.2",
@@ -63,6 +63,8 @@
     "glob": "^7.1.2",
     "imports-loader": "^0.7.1",
     "jest": "^22.1.4",
+    "less": "^2.7.3",
+    "less-loader": "^4.0.6",
     "node-sass": "^4.3.0",
     "postcss-custom-properties": "^6.1.0",
     "postcss-loader": "^2.0.10",

--- a/rails/client/themes/default.json
+++ b/rails/client/themes/default.json
@@ -1,0 +1,6 @@
+{
+  "@primary-color": "#1db954",
+  "@font-size-base": "12px",
+  "@font-size-sm": "10px",
+  "@font-family": "'Helvetica Neue', Helvetica, Arial, sans-serif"
+}

--- a/rails/client/webpack.config.js
+++ b/rails/client/webpack.config.js
@@ -1,5 +1,6 @@
 const webpack = require('webpack');
 const path = require('path');
+const theme = require('./themes/default');
 
 const resolve = path.resolve;
 
@@ -83,6 +84,50 @@ const config = {
         test: /\.jsx?$/,
         use: 'babel-loader',
         exclude: /node_modules/,
+      },
+      {
+        test: /\.(less)$/,
+        use: ExtractTextPlugin.extract({
+          fallback: 'style-loader',
+          use: [
+            {
+              loader: 'css-loader',
+              options: {
+                sourceMap: true,
+                importLoaders: 2,
+                localIdentName: '[name]_[local]_[hash:base64:5]',
+              },
+            },
+            {
+              loader: 'postcss-loader',
+              options: {
+                ident: 'postcss',
+                plugins() {
+                  return [
+                    Autoprefixer({
+                      browsers: [
+                        'ie >= 10',
+                        'last 2 versions',
+                        'last 2 android versions',
+                        'last 2 and_chr versions',
+                        'iOS >= 8',
+                      ],
+                    }),
+                    CustomProperties({
+                      warnings: false,
+                    }),
+                  ];
+                },
+              },
+            },
+            {
+              loader: 'less-loader',
+              options: {
+                modifyVars: theme,
+              },
+            },
+          ],
+        }),
       },
       {
         test: /\.(scss|css)$/,


### PR DESCRIPTION
### Summary
Ant 3.0 Change Log: https://ant.design/changelog#3.0.0

Changes:
- Modals cannot be within the same click target that launches them. Many components previously using modals now return Arrays ( thanks to React 16 ) so the modal and click target are siblings.
- Ant removed the majority of the global styles, list specifically needed margin and padding style resets.
- Ant increased the default font-size, to remain visually passive we are utilizing ant's theming approach to revert it back. https://ant.design/docs/react/customize-theme
- Input refs changed slightly. 

Resolves #122.

Thanks for contributing to Kaiju.
@cerner/kaiju

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
