### PR TITLE
Added the babel-polyfill to each entry

### DIFF
--- a/rails/client/package-lock.json
+++ b/rails/client/package-lock.json
@@ -1171,7 +1171,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
       "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "core-js": "2.5.4",
@@ -1181,8 +1180,7 @@
         "regenerator-runtime": {
           "version": "0.10.5",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
-          "dev": true
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
         }
       }
     },

--- a/rails/client/package.json
+++ b/rails/client/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "antd": "^3.2.3",
     "axios": "^0.17.1",
+    "babel-polyfill": "^6.26.0",
     "classnames": "^2.2.5",
     "github-markdown-css": "^2.10.0",
     "humps": "^2.0.1",
@@ -48,7 +49,6 @@
     "babel-plugin-import": "^1.1.1",
     "babel-plugin-transform-object-assign": "^6.22.0",
     "babel-plugin-transform-object-rest-spread": "^6.22.0",
-    "babel-polyfill": "^6.23.0",
     "babel-preset-es2015": "^6.22.0",
     "babel-preset-react": "^6.23.0",
     "babel-runtime": "^6.23.0",

--- a/rails/client/webpack.config.js
+++ b/rails/client/webpack.config.js
@@ -22,16 +22,13 @@ const config = {
   context: resolve(__dirname),
 
   entry: {
-    attributes: './app/bundles/kaiju/startup/attributesRegistration',
-    code: './app/bundles/kaiju/startup/codeRegistration',
-    component: './app/bundles/kaiju/startup/componentRegistration',
-    guide: './app/bundles/kaiju/startup/guideRegistration',
-    launch: './app/bundles/kaiju/startup/launchPageRegistration',
-    preview: [
-      './app/bundles/kaiju/startup/previewRegistration',
-      'babel-polyfill',
-    ],
-    project: './app/bundles/kaiju/startup/projectRegistration',
+    attributes: ['babel-polyfill', './app/bundles/kaiju/startup/attributesRegistration'],
+    code: ['babel-polyfill', './app/bundles/kaiju/startup/codeRegistration'],
+    component: ['babel-polyfill', './app/bundles/kaiju/startup/componentRegistration'],
+    guide: ['babel-polyfill', './app/bundles/kaiju/startup/guideRegistration'],
+    launch: ['babel-polyfill', './app/bundles/kaiju/startup/launchPageRegistration'],
+    preview: ['babel-polyfill', './app/bundles/kaiju/startup/previewRegistration'],
+    project: ['babel-polyfill', './app/bundles/kaiju/startup/projectRegistration'],
   },
 
   output: {


### PR DESCRIPTION
### Summary
Updated the entry packages to include the babel-polyfill. This will enable backwards compatibility of the workspace preview in older browsers, specifically IE 10.

Thanks for contributing to Kaiju.
@cerner/kaiju

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
