### PR TITLE
Fix - Prevent pixel rounding from expanding and causing a scrollbar

### DIFF
--- a/rails/client/app/bundles/kaiju/components/Component/utilities/highlight.js
+++ b/rails/client/app/bundles/kaiju/components/Component/utilities/highlight.js
@@ -57,8 +57,8 @@ const addHighlight = (target) => {
 
   highlightReference.innerHTML = '';
   highlightReference.style.display = '';
-  highlightReference.style.height = `${rect.height}px`;
-  highlightReference.style.width = `${rect.width}px`;
+  highlightReference.style.height = `${rect.height - 2}px`;
+  highlightReference.style.width = `${rect.width - 2}px`;
 
   tether = new Tether({
     element: highlightReference,

--- a/rails/client/app/bundles/kaiju/components/Component/utilities/overlay.js
+++ b/rails/client/app/bundles/kaiju/components/Component/utilities/overlay.js
@@ -87,8 +87,8 @@ const addOverlay = (target) => {
 
   overlayReference.innerHTML = '';
   overlayReference.style.display = '';
-  overlayReference.style.height = `${rect.height}px`;
-  overlayReference.style.width = `${rect.width}px`;
+  overlayReference.style.height = `${rect.height - 2}px`;
+  overlayReference.style.width = `${rect.width - 2}px`;
 
   overlayReference.appendChild(getTargetLabel(target, rect));
 

--- a/rails/client/package-lock.json
+++ b/rails/client/package-lock.json
@@ -122,9 +122,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "16.3.14",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.3.14.tgz",
-      "integrity": "sha512-wNUGm49fPl7eE2fnYdF0v5vSOrUMdKMQD/4NwtQRnb6mnPwtkhabmuFz37eq90+hhyfz0pWd38jkZHOcaZ6LGw==",
+      "version": "16.3.16",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.3.16.tgz",
+      "integrity": "sha512-fM7YX3Q9a915DXi8T06F8906bWv19sbkVO+k5PUYRIWXU2PINLEHbMMGgySem2phwF6En0+HGI6MOrobp+Ya1g==",
       "optional": true,
       "requires": {
         "csstype": "2.5.3"
@@ -11990,7 +11990,7 @@
       "resolved": "https://registry.npmjs.org/react-animate-height/-/react-animate-height-0.10.10.tgz",
       "integrity": "sha512-p5YSnW2L2sT6EuEsFqwAnbHgNC9yAoAwej/tYFBfWw61MaaAP71msyT84Vy3iKPrncUuACYWoKhGQVoqRISCOg==",
       "requires": {
-        "@types/react": "16.3.14",
+        "@types/react": "16.3.16",
         "classnames": "2.2.5",
         "prop-types": "15.6.1"
       }
@@ -16033,9 +16033,9 @@
       }
     },
     "tether": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/tether/-/tether-1.4.4.tgz",
-      "integrity": "sha512-bagKeRRo3vEynHnO3GB7/jB3Q4YIf0mN7gXM/nR0wZvNHkPrwmZemg1w0C32JZP0prHZUwxGwoX5CdA7tuIDEw=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/tether/-/tether-1.4.0.tgz",
+      "integrity": "sha1-D5+hcfdb9YSF2BSelHmdeudNHBo="
     },
     "text-table": {
       "version": "0.2.0",

--- a/rails/client/package-lock.json
+++ b/rails/client/package-lock.json
@@ -16033,9 +16033,9 @@
       }
     },
     "tether": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/tether/-/tether-1.4.0.tgz",
-      "integrity": "sha1-D5+hcfdb9YSF2BSelHmdeudNHBo="
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/tether/-/tether-1.4.4.tgz",
+      "integrity": "sha512-bagKeRRo3vEynHnO3GB7/jB3Q4YIf0mN7gXM/nR0wZvNHkPrwmZemg1w0C32JZP0prHZUwxGwoX5CdA7tuIDEw=="
     },
     "text-table": {
       "version": "0.2.0",

--- a/rails/client/package.json
+++ b/rails/client/package.json
@@ -37,7 +37,7 @@
     "terra-i18n": "^2.0.0",
     "terra-icon": "^2.0.0",
     "terra-kaiju-plugin": "0.11.0",
-    "tether": "1.4.0",
+    "tether": "^1.4.0",
     "uniqid": "^4.1.1"
   },
   "devDependencies": {

--- a/rails/client/package.json
+++ b/rails/client/package.json
@@ -37,7 +37,7 @@
     "terra-i18n": "^2.0.0",
     "terra-icon": "^2.0.0",
     "terra-kaiju-plugin": "0.11.0",
-    "tether": "^1.4.0",
+    "tether": "1.4.0",
     "uniqid": "^4.1.1"
   },
   "devDependencies": {

--- a/rails/client/webpack.config.js
+++ b/rails/client/webpack.config.js
@@ -12,7 +12,7 @@ const CustomProperties = require('postcss-custom-properties');
 const GatherDependencies = require('./plugins/gather-dependencies');
 const ManifestPlugin = require('webpack-manifest-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
-const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
+// const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
 
 const merge = require('webpack-merge');
@@ -163,7 +163,7 @@ const prodConfig = {
         parallel: true,
         sourceMap: true,
       }),
-      new OptimizeCSSAssetsPlugin({}),
+      // new OptimizeCSSAssetsPlugin({}),
     ],
   },
 };


### PR DESCRIPTION
### Summary
The overlay for the selected component / hovered component could sometimes calculate to be too tall or too wide causing a scrollbar to appear and make the workspace content jump and shift.

This reduces the widths and heights slightly to prevent the browser rounding from being inaccurate and rounding over the available width / height.

Thanks for contributing to Kaiju.
@cerner/kaiju

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
