### PR TITLE
Update - Disabled StackProf logging to prevent maxing out disk space

### DIFF
--- a/rails/config/application.rb
+++ b/rails/config/application.rb
@@ -19,7 +19,8 @@ module Kaiju
     config.cache_store = :redis_store, Rails.configuration.x.session_location, { expires_in: 90.minutes }
     config.autoload_paths << Rails.root.join('lib')
     config.eager_load_paths << Rails.root.join('lib')
-    config.middleware.use(StackProf::Middleware, enabled: true, mode: :wall, interval: 1000, save_every: 5)
+    # Disabling to prevent the stack logs from filling up disk space.
+    # config.middleware.use(StackProf::Middleware, enabled: true, mode: :wall, interval: 1000, save_every: 5)
     config.after_initialize do
       Time.include CoreExtensions::Time::TimeExtensions
       ComponentInformation.components('terra')


### PR DESCRIPTION
### Summary
The logs from StackProf periodically fill up the available disk space and cause the deployment to crash. Disabling the logging until a better solution is found.

Thanks for contributing to Kaiju.
@cerner/kaiju

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
