### PR TITLE
Updated - Sort project names alphabetically on the launch page

### DIFF
--- a/rails/app/models/kaiju/user_json.rb
+++ b/rails/app/models/kaiju/user_json.rb
@@ -38,9 +38,10 @@ module Kaiju
       hash['inactive_projects'] = ProjectJson.map_ids(hash['projects'], true) do |project_id|
         ProjectJson.as_json(project_id, base_url, lite: true)
       end
-      hash['projects'] = ProjectJson.map_ids(hash['projects']) do |project_id|
+      projects = ProjectJson.map_ids(hash['projects']) do |project_id|
         ProjectJson.as_json(project_id, base_url, lite: true)
       end
+      hash['projects'] = projects.sort_by { |project| project['name'].downcase }
       hash['shared_projects'] = ProjectJson.map_ids(hash['shared_projects']) do |project_id|
         ProjectJson.as_json(project_id, base_url, lite: true)
       end

--- a/rails/changelog.md
+++ b/rails/changelog.md
@@ -5,6 +5,7 @@
 ### Enhancements
 - Added multiple and tag Select variants
 - Added a placeholder attribute for the Select
+- Added the component version in the tooltip of each component
 - Adjustments to the workspace display and overlays
 - Project and workspace names are now sorted alphabetically
 - Enabled IE 10 support for Kaiju Previews

--- a/rails/changelog.md
+++ b/rails/changelog.md
@@ -5,7 +5,7 @@
 ### Enhancements
 - Added multiple and tag Select variants
 - Added a placeholder attribute for the Select
-- Added the component version in the tooltip of each component
+- Added the version number in the tooltip of each component
 - Adjustments to the workspace display and overlays
 - Project and workspace names are now sorted alphabetically
 - Enabled IE 10 support for Kaiju Previews

--- a/rails/changelog.md
+++ b/rails/changelog.md
@@ -6,7 +6,7 @@
 - Added multiple and tag Select variants
 - Added a placeholder attribute for the Select
 - Adjustments to the workspace display and overlays
-- Project names are now sorted alphabetically
+- Project and workspace names are now sorted alphabetically
 - Enabled IE 10 support for Kaiju Previews
 
 ## March 14th, 2018

--- a/rails/changelog.md
+++ b/rails/changelog.md
@@ -6,6 +6,7 @@
 - Added multiple and tag Select variants
 - Added a placeholder attribute for the Select
 - Adjustments to the workspace display and overlays
+- Project names are now sorted alphabetically
 
 ## March 14th, 2018
 ### New Components

--- a/rails/changelog.md
+++ b/rails/changelog.md
@@ -7,6 +7,7 @@
 - Added a placeholder attribute for the Select
 - Adjustments to the workspace display and overlays
 - Project names are now sorted alphabetically
+- Enabled IE 10 support for Kaiju Previews
 
 ## March 14th, 2018
 ### New Components

--- a/rails/client/app/bundles/kaiju/components/Project/components/DraggableItem/DraggableItem.jsx
+++ b/rails/client/app/bundles/kaiju/components/Project/components/DraggableItem/DraggableItem.jsx
@@ -29,13 +29,22 @@ const propTypes = {
    * The component name.
    */
   name: PropTypes.string,
+  /**
+   * The component version.
+   */
+  version: PropTypes.string,
 };
 
 const DraggableItem = ({
-  display, description, documentation, library, name,
+  display,
+  description,
+  documentation,
+  library,
+  name,
+  version,
 }) => {
   /**
-   * Appends component data to the event
+   * Appends component data to the event.
    */
   function handleDragStart(event) {
     select(null);
@@ -43,16 +52,38 @@ const DraggableItem = ({
   }
 
   const IconType = iconMap[name];
-  const resource = <a className={cx('link')} href={documentation} target="_blank" rel="noopener noreferrer">See more</a>;
-  const info = documentation ? <span>{description}. {resource}</span> : description;
 
   return (
     <li className={cx('item')} draggable onDragStart={handleDragStart}>
       <span className={cx('display')}>
         {IconType && <IconType className={cx('icon')} />}{display}
       </span>
-      <span className={cx('description')}>
-        <Tooltip placement="right" title={info}>
+      <span className={cx('info')}>
+        <Tooltip
+          placement="right"
+          overlayClassName="kaiju-tooltip"
+          title={() => (
+            <div>
+              <div className={cx('header')}>
+                <span className="display">
+                  {display}
+                </span>
+                <span className={cx('version')}>
+                  v. {version}
+                </span>
+              </div>
+              <div className={cx('description')}>
+                {description}
+              </div>
+              <div className={cx('documentation')}>
+                Still not sure?
+                <a className={cx('link')} href={documentation} target="_blank" rel="noopener noreferrer">
+                  View documentation
+                </a>
+              </div>
+            </div>
+          )}
+        >
           <Icon type="question-circle-o" />
         </Tooltip>
       </span>

--- a/rails/client/app/bundles/kaiju/components/Project/components/DraggableItem/DraggableItem.scss
+++ b/rails/client/app/bundles/kaiju/components/Project/components/DraggableItem/DraggableItem.scss
@@ -1,13 +1,13 @@
 :local {
-  .description {
+  .info {
     cursor: pointer;
     margin-left: auto;
-    margin-right: 5px;
+    margin-right: 0.35714285714285715rem;
     visibility: hidden;
   }
 
   .icon {
-    margin-right: 5px;
+    margin-right: 0.35714285714285715rem;
   }
 
   .item {
@@ -16,12 +16,12 @@
     display: flex;
     flex: 0 0 auto;
     list-style-type: none;
-    padding: 5px 0;
+    padding: 0.35714285714285715rem 0;
 
     &:hover {
       background-color: var(--kaiju-theme-hover-active, #282828);
 
-      .description {
+      .info {
         visibility: visible;
       }
     }
@@ -29,9 +29,38 @@
 
   .link {
     color: var(--kaiju-theme-color, #1db954);
+    padding-left: 0.35714285714285715rem;
 
     &:hover {
       color: rgba(29, 185, 84, 0.75);
     }
   }
+
+  .header {
+    background-color: #222;
+    display: flex;
+    padding: 0.5714285714285714rem;
+  }
+
+  .documentation {
+    color: #a1a1a1;
+    padding: 0.5714285714285714rem;
+  }
+
+  .description {
+    padding: 0.5714285714285714rem;
+  }
+
+  .version {
+    color: #a1a1a1;
+    margin-left: auto;
+  }
+}
+
+// Does not use CSS modules because it must target the non CSS module ant class
+.kaiju-tooltip .ant-tooltip-inner {
+  background-color: #000;
+  border-radius: 5px;
+  overflow: hidden;
+  padding: 0;
 }

--- a/rails/client/app/bundles/kaiju/components/Project/containers/StoryBoardContainer.jsx
+++ b/rails/client/app/bundles/kaiju/components/Project/containers/StoryBoardContainer.jsx
@@ -8,7 +8,7 @@ import Card from './CardContainer';
 const mapStateToProps = ({ project, workspaces }) => ({
   project,
   workspaces: Object.keys(workspaces).sort((a, b) => (
-    workspaces[a].name > workspaces[b].name
+    workspaces[a].name.toLowerCase() > workspaces[b].name.toLowerCase()
   )).map(key => <Card key={key} id={key} />),
 });
 

--- a/rails/client/app/bundles/kaiju/components/Project/containers/StoryBoardContainer.jsx
+++ b/rails/client/app/bundles/kaiju/components/Project/containers/StoryBoardContainer.jsx
@@ -7,7 +7,9 @@ import Card from './CardContainer';
 
 const mapStateToProps = ({ project, workspaces }) => ({
   project,
-  workspaces: Object.keys(workspaces).map(key => <Card key={key} id={key} />),
+  workspaces: Object.keys(workspaces).sort((a, b) => (
+    workspaces[a].name > workspaces[b].name
+  )).map(key => <Card key={key} id={key} />),
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/rails/lib/component_information.rb
+++ b/rails/lib/component_information.rb
@@ -59,7 +59,9 @@ class ComponentInformation # rubocop:disable Metrics/ClassLength
     if project_type == 'terra'
       JSON.parse(File.read('whitelist.json')).each do |library|
         Dir[Rails.root.join("client/node_modules/#{library['name']}/kaiju/**/*.json")].each do |file|
-          sources << [library, JSON.parse(File.read(file))]
+          source = JSON.parse(File.read(file))
+          source['version'] = JSON.parse(File.read("client/node_modules/#{source['library']}/package.json"))['version']
+          sources << [library, source]
         end
       end
     end
@@ -194,7 +196,8 @@ class ComponentInformation # rubocop:disable Metrics/ClassLength
       documentation: data['documentation'],
       name: data['name'],
       description: data['description'],
-      library: library
+      library: library,
+      version: data['version']
     }
   end
 

--- a/rails/spec/models/kaiju/user_json_spec.rb
+++ b/rails/spec/models/kaiju/user_json_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-module Kaiju
+module Kaiju # rubocop:disable Metrics/ModuleLength
   describe UserJson do
     before(:context) do
     end
@@ -99,6 +99,33 @@ module Kaiju
         workspace.destroy
         project.destroy
         inactive_project.destroy
+        user.destroy
+      end
+
+      it 'returns a sorted list of projects' do
+        user = Kaiju::UserFactory.new_user('owner', 'name', 'email', 'nickname')
+
+        project1 = Kaiju::ProjectFactory.new_project(user.id, 'blarg')
+        project1.name = 'C'
+
+        project2 = Kaiju::ProjectFactory.new_project(user.id, 'blarg')
+        project2.name = 'A'
+
+        project3 = Kaiju::ProjectFactory.new_project(user.id, 'blarg')
+        project3.name = 'B'
+
+        puts UserJson.as_json(user.id, 'base_url')['projects']
+        expect(UserJson.as_json(user.id, 'base_url')['projects']).to eq(
+          [
+            ProjectJson.as_json(project2.id, 'base_url', lite: true),
+            ProjectJson.as_json(project3.id, 'base_url', lite: true),
+            ProjectJson.as_json(project1.id, 'base_url', lite: true)
+          ]
+        )
+
+        project1.destroy
+        project2.destroy
+        project3.destroy
         user.destroy
       end
     end


### PR DESCRIPTION
### Summary
- Sorted the projects returned from the User JSON
- Sorted the workspace names within a project alphabetically
- Added the component version into the additional information tooltip

#### Before:
![image](https://user-images.githubusercontent.com/6720991/42909649-8016ee92-8aaa-11e8-81c8-392993ca01a1.png)


#### After:
![image](https://user-images.githubusercontent.com/6720991/42909641-776a2f0c-8aaa-11e8-85ac-6e8fff67267a.png)



Thanks for contributing to Kaiju.
@cerner/kaiju

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
