### PR TITLE
Updated - The browser tab will now display the workspace name in preview

### DIFF
--- a/rails/app/controllers/workspaces_controller.rb
+++ b/rails/app/controllers/workspaces_controller.rb
@@ -74,8 +74,11 @@ class WorkspacesController < ApplicationController
 
   # GET /workspace/1/preview
   def preview
-    @ast = params[:workspace_object].ast
-    @author = Kaiju::User.by_id(params[:workspace_object].author.value)
+    workspace_object = params[:workspace_object]
+
+    @ast = workspace_object.ast
+    @title = workspace_object.name.value
+    @author = Kaiju::User.by_id(workspace_object.author.value)
     respond_to do |format|
       format.html { render layout: 'preview' }
     end

--- a/rails/app/views/layouts/preview.html.erb
+++ b/rails/app/views/layouts/preview.html.erb
@@ -1,7 +1,9 @@
 <!DOCTYPE html>
 <html dir="ltr">
 <head>
-  <title>Kaiju</title>
+  <title>
+    <%= @title %>
+  </title>
   <%= csrf_meta_tags %>
   <%= stylesheet_pack_tag 'preview' %>
   <%= javascript_pack_tag 'preview' %>

--- a/rails/changelog.md
+++ b/rails/changelog.md
@@ -9,6 +9,7 @@
 - Adjustments to the workspace display and overlays
 - Project and workspace names are now sorted alphabetically
 - Enabled IE 10 support for Kaiju Previews
+- Preview browser tab will now display the workspace name
 
 ## March 14th, 2018
 ### New Components

--- a/rails/spec/models/kaiju/user_json_spec.rb
+++ b/rails/spec/models/kaiju/user_json_spec.rb
@@ -114,7 +114,6 @@ module Kaiju # rubocop:disable Metrics/ModuleLength
         project3 = Kaiju::ProjectFactory.new_project(user.id, 'blarg')
         project3.name = 'B'
 
-        puts UserJson.as_json(user.id, 'base_url')['projects']
         expect(UserJson.as_json(user.id, 'base_url')['projects']).to eq(
           [
             ProjectJson.as_json(project2.id, 'base_url', lite: true),

--- a/traefik.toml
+++ b/traefik.toml
@@ -23,4 +23,4 @@ defaultEntryPoints = ["http"]
   backend = "node"
   passHostHeader = true
     [frontends.node.routes.test_1]
-    rule = "PathPrefix: /projects/{id}/workspaces/{id}/preview, /projects/{id}/workspaces/{id}/preview_files, /projects/{id}/workspaces/{id}/code_files"
+    # rule = "PathPrefix: /projects/{id}/workspaces/{id}/preview, /projects/{id}/workspaces/{id}/preview_files, /projects/{id}/workspaces/{id}/code_files"


### PR DESCRIPTION
### Summary
Updated the browser title to display the workspace name while in preview.

Previously the tab only displayed as "Kaiju"

![image](https://user-images.githubusercontent.com/6720991/42951009-dd6755a6-8b3a-11e8-92e7-19b5f14e445e.png)


Thanks for contributing to Kaiju.
@cerner/kaiju

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
