### PR TITLE
Fixed - Attribute array generation

### DIFF
--- a/rails/changelog.md
+++ b/rails/changelog.md
@@ -1,3 +1,7 @@
+## July 25th, 2018
+### Fixed
+- Corrected the position labels of generated attributes
+
 ## July 18th, 2018
 ### Enhancements
 - Added multiple and tag Select variants

--- a/rails/client/app/bundles/kaiju/components/Attributes/Attributes.jsx
+++ b/rails/client/app/bundles/kaiju/components/Attributes/Attributes.jsx
@@ -31,7 +31,7 @@ const Attributes = ({ ast }) => {
         const display = isSubComponent ? humanize(name) : <b>{humanize(name)}</b>;
         attributes.push(<li>{humanize(id)}</li>);
         attributes.push(<ul><li>{display}</li><ul>{generateAttributes(properties)}</ul></ul>);
-      } else if (Number.isNaN(key) === false) {
+      } else if (Number.isInteger(key)) {
         attributes.push(<li>{`Position: ${key}`}</li>);
         attributes.push(<ul><li>{value}</li></ul>);
       } else {

--- a/rails/client/app/bundles/kaiju/components/Attributes/Attributes.jsx
+++ b/rails/client/app/bundles/kaiju/components/Attributes/Attributes.jsx
@@ -31,7 +31,7 @@ const Attributes = ({ ast }) => {
         const display = isSubComponent ? humanize(name) : <b>{humanize(name)}</b>;
         attributes.push(<li>{humanize(id)}</li>);
         attributes.push(<ul><li>{display}</li><ul>{generateAttributes(properties)}</ul></ul>);
-      } else if (Number.isInteger(parseInt(key, 10))) {
+      } else if (Number.isNaN(parseInt(key, 10)) === false) {
         attributes.push(<li>{`Position: ${key}`}</li>);
         attributes.push(<ul><li>{value}</li></ul>);
       } else {

--- a/rails/client/app/bundles/kaiju/components/Attributes/Attributes.jsx
+++ b/rails/client/app/bundles/kaiju/components/Attributes/Attributes.jsx
@@ -31,7 +31,7 @@ const Attributes = ({ ast }) => {
         const display = isSubComponent ? humanize(name) : <b>{humanize(name)}</b>;
         attributes.push(<li>{humanize(id)}</li>);
         attributes.push(<ul><li>{display}</li><ul>{generateAttributes(properties)}</ul></ul>);
-      } else if (Number.isInteger(key)) {
+      } else if (Number.isInteger(parseInt(key, 10))) {
         attributes.push(<li>{`Position: ${key}`}</li>);
         attributes.push(<ul><li>{value}</li></ul>);
       } else {


### PR DESCRIPTION
### Summary
The integer check for array indexes was returning false positives. This update parses the key before checking for number.

*Before*
![image](https://user-images.githubusercontent.com/6720991/43219909-422a1078-900e-11e8-9436-208fa0332822.png)

*After*
![image](https://user-images.githubusercontent.com/6720991/43219997-6e9f7990-900e-11e8-96f8-f68f76952c24.png)


Thanks for contributing to Kaiju.
@cerner/kaiju

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
