### PR TITLE
Fixed - Prevent browser default actions for keyboard shortcuts

### DIFF
--- a/rails/changelog.md
+++ b/rails/changelog.md
@@ -1,6 +1,7 @@
-## July 25th, 2018
+## August 6th, 2018
 ### Fixed
 - Corrected the position labels of generated attributes
+- The keyboard shortcut for delete will no longer navigate the browser backwards in Firefox
 
 ## July 18th, 2018
 ### Enhancements

--- a/rails/client/app/bundles/kaiju/components/Component/utilities/dispatcher.js
+++ b/rails/client/app/bundles/kaiju/components/Component/utilities/dispatcher.js
@@ -217,6 +217,9 @@ const registerDispatcher = (store, root) => {
    */
   const redo = () => {
     post({ message: 'kaiju-redo' });
+
+    // Returning false will prevent default browser actions for events bound using mousetrap.
+    return false;
   };
 
   /**
@@ -345,7 +348,7 @@ const registerDispatcher = (store, root) => {
   Mousetrap.bind(['command+v', 'ctrl+v'], paste);
   Mousetrap.bind(['command+z', 'ctrl+z'], undo);
   Mousetrap.bind(['command+shift+z', 'ctrl+shift+z'], redo);
-  Mousetrap.bind(['backspace', 'delete'], () => destroy(getSelectedComponent()));
+  Mousetrap.bind(['backspace', 'delete'], () => { destroy(getSelectedComponent()); return false; });
   Mousetrap.bind(['command+d', 'ctrl+d'], () => { duplicate(getSelectedComponent()); return false; });
 
   window.addEventListener('click', selectTarget);

--- a/rails/client/app/bundles/kaiju/components/Project/components/ActionBar/ActionBar.jsx
+++ b/rails/client/app/bundles/kaiju/components/Project/components/ActionBar/ActionBar.jsx
@@ -47,10 +47,17 @@ const propTypes = {
 class ActionBar extends React.Component {
   static deselect() {
     select(null);
+
+
+    // Returning false will prevent default actions for events bound using mousetrap.
+    return false;
   }
 
   static destroy() {
     destroy();
+
+    // Returning false will prevent default browser actions for events bound using mousetrap.
+    return false;
   }
 
   constructor() {
@@ -96,7 +103,7 @@ class ActionBar extends React.Component {
     if (selectedComponent) {
       duplicate(selectedComponent.id);
 
-      // Returning false is a feature of mousetrap to prevent default actions.
+      // Returning false will prevent default browser actions for events bound using mousetrap.
       return false;
     }
 
@@ -122,6 +129,9 @@ class ActionBar extends React.Component {
           }
         }
       });
+
+    // Returning false will prevent default browser actions for events bound using mousetrap.
+    return false;
   }
 
   redo() {
@@ -135,6 +145,9 @@ class ActionBar extends React.Component {
           }
         }
       });
+
+    // Returning false will prevent default browser actions for events bound using mousetrap.
+    return false;
   }
 
   render() {


### PR DESCRIPTION
### Additional Details
Returning false in functions bound using mousetrap will prevent default browser actions. 

https://github.com/ccampbell/mousetrap

Using the keyboard delete key to delete selected components was navigating the browser backwards in Firefox

Thanks for contributing to Kaiju.
@cerner/kaiju

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
