### PR TITLE
Fixed - Corrected view scaling

### DIFF
--- a/rails/app/views/layouts/application.html.erb
+++ b/rails/app/views/layouts/application.html.erb
@@ -5,6 +5,7 @@
   <%= csrf_meta_tags %>
   <%= stylesheet_pack_tag 'project' %>
   <%= javascript_pack_tag 'project' %>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 <body>
 

--- a/rails/app/views/layouts/attributes.html.erb
+++ b/rails/app/views/layouts/attributes.html.erb
@@ -4,6 +4,7 @@
   <title>Kaiju</title>
   <%= csrf_meta_tags %>
   <%= javascript_pack_tag 'attributes' %>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 <body>
 

--- a/rails/app/views/layouts/code.html.erb
+++ b/rails/app/views/layouts/code.html.erb
@@ -5,6 +5,7 @@
   <%= csrf_meta_tags %>
   <%= stylesheet_pack_tag 'code' %>
   <%= javascript_pack_tag 'code' %>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 <body>
 

--- a/rails/app/views/layouts/components.html.erb
+++ b/rails/app/views/layouts/components.html.erb
@@ -5,6 +5,7 @@
   <%= csrf_meta_tags %>
   <%= stylesheet_pack_tag 'component' %>
   <%= javascript_pack_tag 'component' %>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 <body>
 

--- a/rails/app/views/layouts/guide.html.erb
+++ b/rails/app/views/layouts/guide.html.erb
@@ -5,6 +5,7 @@
   <%= csrf_meta_tags %>
   <%= stylesheet_pack_tag 'guide' %>
   <%= javascript_pack_tag 'guide' %>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 <body>
 

--- a/rails/app/views/layouts/health.html.erb
+++ b/rails/app/views/layouts/health.html.erb
@@ -3,6 +3,7 @@
 <head>
   <title>Kaiju</title>
   <%= csrf_meta_tags %>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 <body>
 

--- a/rails/app/views/layouts/launch.html.erb
+++ b/rails/app/views/layouts/launch.html.erb
@@ -5,6 +5,7 @@
   <%= csrf_meta_tags %>
   <%= stylesheet_pack_tag 'launch' %>
   <%= javascript_pack_tag 'launch' %>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 <body>
 

--- a/rails/app/views/layouts/preview.html.erb
+++ b/rails/app/views/layouts/preview.html.erb
@@ -7,6 +7,7 @@
   <%= csrf_meta_tags %>
   <%= stylesheet_pack_tag 'preview' %>
   <%= javascript_pack_tag 'preview' %>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 <body>
 

--- a/rails/changelog.md
+++ b/rails/changelog.md
@@ -1,6 +1,7 @@
 ## August 6th, 2018
 ### Fixed
 - Corrected the position labels of generated attributes
+- Corrected the workspace preview scaling
 - The keyboard shortcut for delete will no longer navigate the browser backwards in Firefox
 
 ## July 18th, 2018

--- a/rails/changelog.md
+++ b/rails/changelog.md
@@ -1,4 +1,4 @@
-## August 6th, 2018
+## August 9th, 2018
 ### Fixed
 - Corrected the position labels of generated attributes
 - Corrected the workspace preview scaling


### PR DESCRIPTION
### Summary
The views in Kaiju would scale content between devices, this fix sets an initial scale to preserve scaling between mobile, tablet and desktop.

Example of scaling: 
![image](https://user-images.githubusercontent.com/6720991/43910600-df3cb3d8-9bc2-11e8-8c95-0fba1f907cd3.png)

After Change:
![image](https://user-images.githubusercontent.com/6720991/43910636-f73f074c-9bc2-11e8-9110-d373b472c179.png)


Thanks for contributing to Kaiju.
@cerner/kaiju

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
